### PR TITLE
nginx-util: do not use fallthrough attribute

### DIFF
--- a/net/nginx-util/src/nginx-ssl-util.hpp
+++ b/net/nginx-util/src/nginx-ssl-util.hpp
@@ -166,8 +166,8 @@ static constexpr auto _escape = _Line{
         std::string ret{};
         for (char c : strptr) {
             switch (c) {
-                case '^': ret += '\\'; [[fallthrough]];
-                case '_': [[fallthrough]];
+                case '^': ret += '\\'; /* fallthrough */
+                case '_': /* fallthrough */
                 case '-': ret += c; break;
                 default:
                     if ((isalpha(c) != 0) || (isdigit(c) != 0)) {


### PR DESCRIPTION
fixes issue：https://github.com/immortalwrt/immortalwrt/issues/384