### PR TITLE
dockerd: generate network config with "device" options

### DIFF
--- a/utils/dockerd/files/dockerd.init
+++ b/utils/dockerd/files/dockerd.init
@@ -43,7 +43,7 @@ uciadd() {
 		logger -t "dockerd-init" -p notice "Adding docker default interface to network uci config (${iface})"
 		uci_quiet add network interface
 		uci_quiet rename network.@interface[-1]="${iface}"
-		uci_quiet set network.@interface[-1].ifname="${device}"
+		uci_quiet set network.@interface[-1].device="${device}"
 		uci_quiet set network.@interface[-1].proto="none"
 		uci_quiet set network.@interface[-1].auto="0"
 		uci_quiet commit network
@@ -56,7 +56,7 @@ uciadd() {
 		uci_quiet rename network.@device[-1]="${device}"
 		uci_quiet set network.@device[-1].type="bridge"
 		uci_quiet set network.@device[-1].name="${device}"
-		uci_quiet add_list network.@device[-1].ifname="${device}"
+		uci_quiet add_list network.@device[-1].ports="${device}"
 		uci_quiet commit network
 	fi
 


### PR DESCRIPTION
Because OP master replace "ifname" with "device" , dockerd.init must be changed.