### PR TITLE
mosdns:Disable upx compress for mips64

### DIFF
--- a/net/mosdns/Makefile
+++ b/net/mosdns/Makefile
@@ -57,6 +57,7 @@ config MOSDNS_COMPRESS_GOPROXY
 
 config MOSDNS_COMPRESS_UPX
 	bool "Compress executable files with UPX"
+	depends on @!mips64
 	default y
 endef
 


### PR DESCRIPTION
 Unsupported and cause build errors.