### PR TITLE
hysteria:Disable upx compress for mips64

### DIFF
--- a/net/hysteria/Makefile
+++ b/net/hysteria/Makefile
@@ -54,6 +54,7 @@ config HYSTERIA_COMPRESS_GOPROXY
 
 config HYSTERIA_COMPRESS_UPX
 	bool "Compress executable files with UPX"
+	depends on @!mips64
 	default y
 endef
 


### PR DESCRIPTION
Unsupported and cause build errors.