### PR TITLE
brook:Disable upx compress for mips64

### DIFF
--- a/net/brook/Makefile
+++ b/net/brook/Makefile
@@ -55,6 +55,7 @@ define Package/brook/config
 
 	config BROOK_COMPRESS_UPX
 		bool "Compress executable files with UPX"
+		depends on @!mips64
 		default y
 endef
 


### PR DESCRIPTION
Unsupported and cause build errors.