### PR TITLE
v2ray-core:Disable upx compress for mips64

### DIFF
--- a/net/v2ray-core/Makefile
+++ b/net/v2ray-core/Makefile
@@ -117,6 +117,7 @@ config V2RAY_CORE_COMPRESS_GOPROXY
 
 config V2RAY_CORE_COMPRESS_UPX
 	bool "Compress executable files with UPX"
+	depends on @!mips64
 	default y
 endmenu
 endef
@@ -127,6 +128,7 @@ menu "v2ray-ctl Configuration"
 
 config V2RAY_CTL_COMPRESS_GOPROXY
 	bool "Compiling with GOPROXY proxy"
+	depends on @!mips64
 	default n
 
 config V2RAY_CTL_COMPRESS_UPX


### PR DESCRIPTION
Unsupported and cause build errors.