### PR TITLE
v2ray-plugin:Disable upx compress for mips64

### DIFF
--- a/net/v2ray-plugin/Makefile
+++ b/net/v2ray-plugin/Makefile
@@ -44,6 +44,7 @@ config V2RAY_PLUGIN_COMPRESS_GOPROXY
 
 config V2RAY_PLUGIN_COMPRESS_UPX
 	bool "Compress executable files with UPX"
+	depends on @!mips64
 	default y
 endef
 


### PR DESCRIPTION
Unsupported and cause build errors.