### PR TITLE
v2raya:Disable upx compress for mips64

### DIFF
--- a/net/v2raya/Makefile
+++ b/net/v2raya/Makefile
@@ -63,6 +63,7 @@ config V2RAYA_COMPRESS_GOPROXY
 
 config V2RAYA_COMPRESS_UPX
 	bool "Compress executable files with UPX"
+	depends on @!mips64
 	default y
 endef
 


### PR DESCRIPTION
Unsupported and cause build errors.