### PR TITLE
xray-core:Disable upx compress for mips64

### DIFF
--- a/net/xray-core/Makefile
+++ b/net/xray-core/Makefile
@@ -88,6 +88,7 @@ config XRAY_CORE_COMPRESS_GOPROXY
 
 config XRAY_CORE_COMPRESS_UPX
 	bool "Compress executable files with UPX"
+	depends on @!mips64
 	default y
 endmenu
 endef


### PR DESCRIPTION
Unsupported and cause build errors.