### PR TITLE
naiveproxy: fix missing macros

### DIFF
--- a/net/naiveproxy/patches/100-macros.patch
+++ b/net/naiveproxy/patches/100-macros.patch
@@ -1,0 +1,38 @@
+--- a/src/base/memory/tagging.cc
++++ b/src/base/memory/tagging.cc
+@@ -17,22 +17,25 @@
+ #define PR_GET_TAGGED_ADDR_CTRL 56
+ #define PR_TAGGED_ADDR_ENABLE (1UL << 0)
+ 
+-#if BUILDFLAG(IS_LINUX)
+-#include <linux/version.h>
+-
+-// Linux headers already provide these since v5.10.
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0)
+-#define HAS_PR_MTE_MACROS
+-#endif
+-#endif
+-
+-#ifndef HAS_PR_MTE_MACROS
++#ifndef PR_MTE_TCF_SHIFT
+ #define PR_MTE_TCF_SHIFT 1
++#endif
++#ifndef PR_MTE_TCF_NONE
+ #define PR_MTE_TCF_NONE (0UL << PR_MTE_TCF_SHIFT)
++#endif
++#ifndef PR_MTE_TCF_SYNC
+ #define PR_MTE_TCF_SYNC (1UL << PR_MTE_TCF_SHIFT)
++#endif
++#ifndef PR_MTE_TCF_ASYNC
+ #define PR_MTE_TCF_ASYNC (2UL << PR_MTE_TCF_SHIFT)
++#endif
++#ifndef PR_MTE_TCF_MASK
+ #define PR_MTE_TCF_MASK (3UL << PR_MTE_TCF_SHIFT)
++#endif
++#ifndef PR_MTE_TAG_SHIFT
+ #define PR_MTE_TAG_SHIFT 3
++#endif
++#ifndef PR_MTE_TAG_MASK
+ #define PR_MTE_TAG_MASK (0xffffUL << PR_MTE_TAG_SHIFT)
+ #endif
+ #endif


### PR DESCRIPTION
Fixes: 08cdee7579266c ("naiveproxy: Update 99.0.4844.51-1")

Signed-off-by: Tianling Shen <cnsztl@immortalwrt.org>