### PR TITLE
glib2: disable fortify source

### DIFF
--- a/libs/glib2/Makefile
+++ b/libs/glib2/Makefile
@@ -25,6 +25,7 @@ HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/glib-$(PKG_VERSION)
 PKG_BUILD_DEPENDS:=meson/host gettext-full libiconv/host
 HOST_BUILD_DEPENDS:=meson/host gettext-full/host libiconv/host libffi/host
 PKG_CONFIG_DEPENDS:=CONFIG_BUILD_NLS
+PKG_FORTIFY_SOURCE:=0
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/host-build.mk


### PR DESCRIPTION
The glib2 package fails to build when CONFIG_PKG_FORTIFY_SOURCE_1 or CONFIG_PKG_FORTIFY_SOURCE_2 is enabled in the OpenWrt config:

In file included from ../glib/libcharset/localcharset.c:28: /home/beaver/Desktop/immortalwrt-mt798x/staging_dir/toolchain-aarch64_cortex-a53_gcc-8.4.0_musl/include/fortify/stdio.h: In function 'snprintf': /home/beaver/Desktop/immortalwrt-mt798x/staging_dir/toolchain-aarch64_cortex-a53_gcc-8.4.0_musl/include/fortify/stdio.h:101:2: error: format not a string literal, argument types not checked [-Werror=format-nonliteral]
  return __orig_snprintf(__s, __n, __f, __builtin_va_arg_pack());
  ^~~~~~
/home/beaver/Desktop/immortalwrt-mt798x/staging_dir/toolchain-aarch64_cortex-a53_gcc-8.4.0_musl/include/fortify/stdio.h: In function 'sprintf': /home/beaver/Desktop/immortalwrt-mt798x/staging_dir/toolchain-aarch64_cortex-a53_gcc-8.4.0_musl/include/fortify/stdio.h:110:3: error: format not a string literal, argument types not checked [-Werror=format-nonliteral]
   __r = __orig_snprintf(__s, __b, __f, __builtin_va_arg_pack());
   ^~~
/home/beaver/Desktop/immortalwrt-mt798x/staging_dir/toolchain-aarch64_cortex-a53_gcc-8.4.0_musl/include/fortify/stdio.h:114:3: error: format not a string literal, argument types not checked [-Werror=format-nonliteral]
   __r = __orig_sprintf(__s, __f, __builtin_va_arg_pack());
   ^~~
cc1: some warnings being treated as errors
ninja: build stopped: subcommand failed.
make[3]: *** [Makefile:130: /home/beaver/Desktop/immortalwrt-mt798x/build_dir/target-aarch64_cortex-a53_musl/glib-2.66.4/.built] Error 1

Disable fortify source for the package as a workaround.