### PR TITLE
dae.init: run like dae's offcical systemd service

### DIFF
--- a/net/dae/files/dae.init
+++ b/net/dae/files/dae.init
@@ -17,6 +17,10 @@ start_service() {
 	local config_file
 	config_get config_file "config" "config_file" "/etc/dae/config.dae"
 
+        if ! "$PROG" validate -c "$config_file"; then
+                return 1
+        fi
+
 	procd_open_instance "$CONF"
 	procd_set_param command "$PROG"
 	procd_append_param command run -c "$config_file"
@@ -32,4 +36,8 @@ start_service() {
 
 service_triggers() {
 	procd_add_reload_trigger "$CONF"
+}
+
+reload_service() {
+        "$PROG" reload "$(cat /var/run/dae.pid)"
 }

--- a/net/dae/files/dae.init
+++ b/net/dae/files/dae.init
@@ -17,9 +17,7 @@ start_service() {
 	local config_file
 	config_get config_file "config" "config_file" "/etc/dae/config.dae"
 
-        if ! "$PROG" validate -c "$config_file"; then
-                return 1
-        fi
+	"$PROG" validate -c "$config_file" || return 1
 
 	procd_open_instance "$CONF"
 	procd_set_param command "$PROG"


### PR DESCRIPTION
1. `/etc/init.d/dae reload` will real work;
2. If dae's config is illegal, dae will show the error and exits.