### PR TITLE
qt6base: fix compilation warning

### DIFF
--- a/libs/qt6base/patches/010-marco.patch
+++ b/libs/qt6base/patches/010-marco.patch
@@ -10,3 +10,14 @@
  #ifdef EM_BLACKFIN
      case EM_BLACKFIN:   d << ", Blackfin"; break;
  #endif
+--- a/src/3rdparty/forkfd/forkfd.c
++++ b/src/3rdparty/forkfd/forkfd.c
+@@ -605,7 +605,7 @@ static int forkfd_fork_fallback(int flags, pid_t *ppid)
+     int death_pipe[2];
+     int sync_pipe[2];
+     int ret;
+-#ifdef __linux__
++#ifdef HAVE_EVENTFD
+     int efd;
+ #endif
+ 


### PR DESCRIPTION
/qtbase-everywhere-src-6.5.0/src/corelib/io/../../3rdparty/forkfd/forkfd.c:609:9: warning: unused variable 'efd' [-Wunused-variable]
  609 |     int efd;
      |         ^~~