### PR TITLE
bitsrunlogin-go: Update to 1.3.8

### DIFF
--- a/net/bitsrunlogin-go/Makefile
+++ b/net/bitsrunlogin-go/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=BitSrunLoginGo
-PKG_VERSION:=3.7
+PKG_VERSION:=1.3.8
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/Mmx233/BitSrunLoginGo/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=7d2130b62cd72a65dc6d5abb3776329c73791bf48d7888a1a32f503c5a04e1d3
+PKG_HASH:=3d64f7cf6c3abc4031812992365c8936a063c3de40027b45e90579bc03ecdbe3
 
 PKG_LICENSE:=AGPL-3.0-only
 PKG_LICENSE_FILES:=LICENSE
@@ -20,6 +20,7 @@ PKG_BUILD_PARALLEL:=1
 PKG_BUILD_FLAGS:=no-mips16
 
 GO_PKG:=github.com/Mmx233/BitSrunLoginGo
+GO_PKG_BUILD_PKG:=github.com/Mmx233/BitSrunLoginGo/cmd/bitsrun/
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk
@@ -41,7 +42,7 @@ define Package/bitsrunlogin-go/install
 	$(call GoPackage/Package/Install/Bin,$(PKG_INSTALL_DIR))
 
 	$(INSTALL_DIR) $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/BitSrunLoginGo $(1)/usr/bin/bitsrunlogin-go
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/bitsrun $(1)/usr/bin/bitsrunlogin-go
 
 	$(INSTALL_DIR) $(1)/etc/config $(1)/etc/init.d
 	$(INSTALL_CONF) $(CURDIR)/files/bitsrunlogin-go.config $(1)/etc/config/bitsrunlogin-go

--- a/net/bitsrunlogin-go/files/bitsrunlogin-go.config
+++ b/net/bitsrunlogin-go/files/bitsrunlogin-go.config
@@ -18,8 +18,6 @@ config bitsrunlogin-go 'config'
 	# Interface name in regex, e.g. "eth0\.[2-3]"
 	# Multi-interfaces mode will be enabled if not empty
 	option 'interfaces' ''
-	# Use interface ip for authentication in multi-interfaces mode
-	option use_dhcp_ip '0'
 
 	# Enable debug log
 	option 'debug' '0'

--- a/net/bitsrunlogin-go/files/bitsrunlogin-go.init
+++ b/net/bitsrunlogin-go/files/bitsrunlogin-go.init
@@ -56,15 +56,10 @@ start_service() {
 	json_add_boolean "skip_cert_verify" "$skip_cert_verify"
 	json_add_int "timeout" "$timeout"
 	[ -z "$interfaces" ] || json_add_string "interfaces" "$interfaces"
-	[ -z "$interfaces" ] || json_add_boolean "use_dhcp_ip" "$use_dhcp_ip"
 	json_close_object
 	json_add_object "guardian"
 	json_add_boolean "enable" 1
 	json_add_int "duration" "$duration"
-	json_close_object
-	json_add_object "daemon"
-	json_add_boolean "enable" 0
-	json_add_string "path" "$RUN_DIR/.BitSrun"
 	json_close_object
 	json_add_object "log"
 	json_add_boolean "debug_level" "$debug"


### PR DESCRIPTION
I have tested the build viability in the official firmware earlier, but the submitted code is not tested because my desktop computer has no power right now. I can try to compile it tomorrow if necessary.