### PR TITLE
smartdns: bump to Release43

### DIFF
--- a/net/smartdns/Makefile
+++ b/net/smartdns/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=smartdns
-PKG_VERSION:=42
+PKG_VERSION:=43
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/pymumu/smartdns/tar.gz/Release$(PKG_VERSION)?
-PKG_HASH:=83bb3c588672dff7fe702223538d6e61a4d475e592643a57d1416aade0b363d0
+PKG_HASH:=2a5e7869603ecb7b0d94e153d938e798f0b8f260cc6062cc095a39116386d8b3
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-Release$(PKG_VERSION)
 
 PKG_MAINTAINER:=Nick Peng <pymumu@gmail.com>


### PR DESCRIPTION
And please cherry-pick to openwrt-21.02 branch.