### PR TITLE
fix(netdata): add netdata-claim.sh dependencies

### DIFF
--- a/admin/netdata/Makefile
+++ b/admin/netdata/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netdata
 PKG_VERSION:=1.38.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>, Daniel Engberg <daniel.engberg.lists@pyret.net>
 PKG_LICENSE:=GPL-3.0-or-later
@@ -33,7 +33,7 @@ define Package/netdata
   SECTION:=admin
   CATEGORY:=Administration
   DEPENDS:=+zlib +libuuid +libuv +libmnl +libjson-c +libopenssl \
-    +libstdcpp +libatomic +protobuf
+    +libstdcpp +libatomic +protobuf +openssl-util +curl +bash
   TITLE:=Real-time performance monitoring tool
   URL:=https://www.netdata.cloud/
 endef


### PR DESCRIPTION
how to use:

```
/etc/init.d/netdata start
netdata-claim.sh -token=xxx -rooms=xxx -url=https://app.netdata.cloud
```
then you can see your device monitor on https://app.netdata.cloud/ .