### PR TITLE
加一个行配置，修正设了密码的ftp账户无法登录的问题

### DIFF
--- a/net/vsftpd/files/vsftpd_prepare
+++ b/net/vsftpd/files/vsftpd_prepare
@@ -254,5 +254,5 @@ fi
 
 output_const "seccomp_sandbox" NO
 output_const "use_localtime" YES
-
+output_const "check_shell" NO
 exit 0


### PR DESCRIPTION
这样在命令行用`passwd ftp`给ftp账户设置密码后
ftp账户才能用密码正常登录