### PR TITLE
Add more jail mount to ddns-go to fix Get IP from CLI

### DIFF
--- a/net/ddns-go/files/ddns-go.init
+++ b/net/ddns-go/files/ddns-go.init
@@ -36,12 +36,16 @@ start_service() {
 	procd_set_param respawn
 	procd_set_param stderr 1
 	procd_set_param user ddns-go
+	procd_set_param env PATH=/usr/sbin:/usr/bin:/sbin:/bin
 
 	procd_add_jail "$CONF" log
 	procd_add_jail_mount_rw "$YAML"
 	procd_add_jail_mount "/etc/localtime"
 	procd_add_jail_mount "/etc/TZ"
 	procd_add_jail_mount "/etc/ssl/"
+	procd_add_jail_mount "/bin/"
+    procd_add_jail_mount "/sbin/"
+    procd_add_jail_mount "/usr/"
 
 	procd_close_instance
 }

--- a/net/ddns-go/files/ddns-go.init
+++ b/net/ddns-go/files/ddns-go.init
@@ -38,15 +38,6 @@ start_service() {
 	procd_set_param user ddns-go
 	procd_set_param env PATH=/usr/sbin:/usr/bin:/sbin:/bin
 
-	procd_add_jail "$CONF" log
-	procd_add_jail_mount_rw "$YAML"
-	procd_add_jail_mount "/etc/localtime"
-	procd_add_jail_mount "/etc/TZ"
-	procd_add_jail_mount "/etc/ssl/"
-	procd_add_jail_mount "/bin/"
-	procd_add_jail_mount "/sbin/"
-	procd_add_jail_mount "/usr/"
-
 	procd_close_instance
 }
 

--- a/net/ddns-go/files/ddns-go.init
+++ b/net/ddns-go/files/ddns-go.init
@@ -36,7 +36,6 @@ start_service() {
 	procd_set_param respawn
 	procd_set_param stderr 1
 	procd_set_param user ddns-go
-	procd_set_param env PATH=/usr/sbin:/usr/bin:/sbin:/bin
 
 	procd_close_instance
 }

--- a/net/ddns-go/files/ddns-go.init
+++ b/net/ddns-go/files/ddns-go.init
@@ -44,8 +44,8 @@ start_service() {
 	procd_add_jail_mount "/etc/TZ"
 	procd_add_jail_mount "/etc/ssl/"
 	procd_add_jail_mount "/bin/"
-    procd_add_jail_mount "/sbin/"
-    procd_add_jail_mount "/usr/"
+	procd_add_jail_mount "/sbin/"
+	procd_add_jail_mount "/usr/"
 
 	procd_close_instance
 }


### PR DESCRIPTION
Because of procd's jail mount, we can't run command like `sh, ip, grep` in ddns-go.
To fix this problem, I set `PATH` to procd env and mount multiple paths to jail.
* `/bin/`: for `sh`
* `/sbin/`: for `ip`
* `/usr/`: for `ip` and it relate libs