### PR TITLE
mosdns: declaring configuration files

### DIFF
--- a/net/mosdns/Makefile
+++ b/net/mosdns/Makefile
@@ -38,6 +38,10 @@ endef
 
 GO_PKG_TARGET_VARS:=$(filter-out CGO_ENABLED=%,$(GO_PKG_TARGET_VARS)) CGO_ENABLED=0
 
+define Package/mosdns/conffiles
+/etc/mosdns/
+endef
+
 define Package/mosdns/install
 	$(call GoPackage/Package/Install/Bin,$(1))
 


### PR DESCRIPTION
Although by default, there is only one file "/etc/mosdns/config.yaml".

However, it is common for users to add other files on their own to work with it.

Therefore, we have chosen to declare the entire "/etc/mosdns/" directory.