### PR TITLE
sing-box: Add control values for stdout and stderr in the config file

### DIFF
--- a/net/sing-box/files/sing-box.conf
+++ b/net/sing-box/files/sing-box.conf
@@ -4,4 +4,5 @@ config sing-box 'main'
 	option user 'sing-box'
 	option conffile '/etc/sing-box/config.json'
 	option workdir '/usr/share/sing-box'
-
+	option log_stderr '1'
+	option log_stdout '1'

--- a/net/sing-box/files/sing-box.init
+++ b/net/sing-box/files/sing-box.init
@@ -9,13 +9,15 @@ PROG="/usr/bin/sing-box"
 start_service() {
 	config_load "$NAME"
 
-	local enabled user group conffile workdir
+	local enabled user group conffile workdir log_stdout log_stderr
 	config_get_bool enabled "main" "enabled" "0"
 	[ "$enabled" -eq "1" ] || return 0
 
 	config_get user "main" "user" "root"
 	config_get conffile "main" "conffile"
 	config_get workdir "main" "workdir" "/usr/share/sing-box"
+	config_get log_stdout "main" "log_stdout" 1
+	config_get log_stderr "main" "log_stderr" 1
 
 	mkdir -p "$workdir"
 	local group="$(id -ng $user)"
@@ -27,8 +29,8 @@ start_service() {
 	# Use root user if you want to use the TUN mode.
 	procd_set_param user "$user"
 	procd_set_param file "$conffile"
-	procd_set_param stdout 1
-	procd_set_param stderr 1
+	procd_set_param stdout "$log_stdout"
+	procd_set_param stderr "$log_stderr"
 	procd_set_param respawn
 
 	procd_close_instance

--- a/net/sing-box/files/sing-box.init
+++ b/net/sing-box/files/sing-box.init
@@ -16,8 +16,8 @@ start_service() {
 	config_get user "main" "user" "root"
 	config_get conffile "main" "conffile"
 	config_get workdir "main" "workdir" "/usr/share/sing-box"
-	config_get log_stdout "main" "log_stdout" 1
-	config_get log_stderr "main" "log_stderr" 1
+	config_get_bool log_stdout "main" "log_stdout" "1"
+	config_get_bool log_stderr "main" "log_stderr" "1"
 
 	mkdir -p "$workdir"
 	local group="$(id -ng $user)"


### PR DESCRIPTION
This pull request adds control bits for **stdout** and **stderr** in the config file of sing-box. We can stop sing-box from spamming the syslog with both control bits disabled.