### PR TITLE
dae: improve init script

### DIFF
--- a/net/dae/files/dae.config
+++ b/net/dae/files/dae.config
@@ -2,4 +2,6 @@
 config dae 'config'
 	option enabled '0'
 	option config_file '/etc/dae/config.dae'
+	option log_maxbackups '1'
+	option log_maxsize '1'
 

--- a/net/dae/files/dae.init
+++ b/net/dae/files/dae.init
@@ -6,6 +6,7 @@ START=99
 
 CONF="dae"
 PROG="/usr/bin/dae"
+LOG_DIR="/var/log/dae"
 
 start_service() {
 	config_load "$CONF"
@@ -19,9 +20,17 @@ start_service() {
 
 	"$PROG" validate -c "$config_file" || return 1
 
+	local log_maxbackups log_maxsize
+	config_get log_maxbackups "config" "log_maxbackups" "1"
+	config_get log_maxsize "config" "log_maxsize" "1"
+
 	procd_open_instance "$CONF"
-	procd_set_param command "$PROG"
-	procd_append_param command run -c "$config_file"
+	procd_set_param command "$PROG" run
+	procd_append_param command --config "$config_file"
+	procd_append_param command --disable-timestamp
+	procd_append_param command --logfile "$LOG_DIR/dae.log"
+	procd_append_param command --logfile-maxbackups "$log_maxbackups"
+	procd_append_param command --logfile-maxsize "$log_maxsize"
 
 	procd_set_param limits core="unlimited"
 	procd_set_param limits nofile="1000000 1000000"
@@ -30,6 +39,10 @@ start_service() {
 	procd_set_param stderr 1
 
 	procd_close_instance
+}
+
+stop_service() {
+	rm -rf "$LOG_DIR"
 }
 
 service_triggers() {


### PR DESCRIPTION
* Print running logs to a file instead of standard output
* Default file log retains a maximum of one history