### PR TITLE
open-app-filter:  workaround insmod issue

### DIFF
--- a/net/open-app-filter/patches/100-workaround-insmod-issue.patch
+++ b/net/open-app-filter/patches/100-workaround-insmod-issue.patch
@@ -1,0 +1,11 @@
+--- a/open-app-filter/files/appfilter.init
++++ b/open-app-filter/files/appfilter.init
+@@ -33,7 +33,7 @@ start_service(){
+ 		fi
+ 	fi
+ 	gen_class.sh /tmp/feature.cfg
+-	insmod oaf
++	modprobe oaf
+ 	/usr/bin/oaf_rule reload
+ 	procd_open_instance
+ 	procd_set_param respawn 60 5 5


### PR DESCRIPTION
switch to using modprobe vs. insmod as it allows more versatility in
  dependency loading.