### PR TITLE
[openwrt-23.05] shadowsocks-rust: update to 1.19.2

### DIFF
--- a/net/shadowsocks-rust/Makefile
+++ b/net/shadowsocks-rust/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=shadowsocks-rust
-PKG_VERSION:=1.18.4
+PKG_VERSION:=1.19.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/shadowsocks/shadowsocks-rust/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=1df8961d4b16f756081a554bf84ded124d43062f92cf36f2ac3f590ee72d22f3
+PKG_HASH:=c7b8176db50073f64650224e7dc49d2aa96f8871a99ac8039bf7ea38eca82528
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Signed-off-by: CATTERY <C_A_T_T_E_R_Y@outlook.com>
(cherry picked from commit https://github.com/immortalwrt/packages/commit/22561a5fb7d323ecbe9b3a6cedcd040faf879b9c)