### PR TITLE
[openwrt-23.05] sing-box: update to 1.9.0

### DIFF
--- a/net/sing-box/Makefile
+++ b/net/sing-box/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sing-box
-PKG_VERSION:=1.8.14
+PKG_VERSION:=1.9.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/SagerNet/sing-box/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=2ba7cfa097f5963ba304d47606e7a6b61bf881eb86cbed78fa6e4efae44a0a5f
+PKG_HASH:=cb1d91e362f4dd7c35f7bb040514414861a045a76301af8257134c65f7a45c36
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Signed-off-by: CATTERY <C_A_T_T_E_R_Y@outlook.com>
(cherry picked from commit https://github.com/immortalwrt/packages/commit/da5d989a1e1743dc192d838fec74647fe4628b90)