### PR TITLE
ddns-go: fix permission denied

### DIFF
--- a/net/ddns-go/Makefile
+++ b/net/ddns-go/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-go
 PKG_VERSION:=6.6.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/jeessy2/ddns-go/tar.gz/v$(PKG_VERSION)?

--- a/net/ddns-go/files/ddns-go.init
+++ b/net/ddns-go/files/ddns-go.init
@@ -23,7 +23,8 @@ start_service() {
 
 	[ -d "${YAML%/*}" ] || mkdir -p "${YAML%/*}"
 	touch "$YAML"
-	chown ddns-go "$YAML"
+	chown ddns-go:ddns-go "$YAML"
+	chmod 0640 "$YAML"
 
 	procd_open_instance "$CONF"
 	procd_set_param command "$PROG"


### PR DESCRIPTION
Try to fix "open /etc/ddns-go/config.yaml: permission denied".