### PR TITLE
shadowsocks-rust: update to 1.20.2

### DIFF
--- a/net/shadowsocks-rust/Makefile
+++ b/net/shadowsocks-rust/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=shadowsocks-rust
-PKG_VERSION:=1.20.1
+PKG_VERSION:=1.20.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/shadowsocks/shadowsocks-rust/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=95bef16ced3d937e085fdce0bc8de33e156c00bdc9c10100778d3e3ff4df95f0
+PKG_HASH:=555f0680621d6ebe19eb6b91356068ca7afabf5ef502bbe2a85d779af03e45b9
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
For more information, visit https://github.com/shadowsocks/shadowsocks-rust/releases/tag/v1.20.2