### PR TITLE
ddns-go: Update to 6.6.4

### DIFF
--- a/net/ddns-go/Makefile
+++ b/net/ddns-go/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-go
-PKG_VERSION:=6.6.3
+PKG_VERSION:=6.6.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/jeessy2/ddns-go/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=72ddbcaa380e61c3cda758dbc2d9831e17bceb34ec1e4ff4d0fe9f0ed5f7e913
+PKG_HASH:=69e90cff0be0cc7968a884109209765cf4d7de346cd13b7e147f1a0f332b63ab
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
ddns-go: Update to 6.6.4

build(deps): bump docker/build-push-action from 5 to 6 
build(deps): bump golang.org/x/net from 0.26.0 to 0.27.0
chore: drop the support of Google Domain

For more information, visit https://github.com/jeessy2/ddns-go/compare/v6.6.3...v6.6.4