### PR TITLE
shadowsocks-rust: update to 1.20.3

### DIFF
--- a/net/shadowsocks-rust/Makefile
+++ b/net/shadowsocks-rust/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=shadowsocks-rust
-PKG_VERSION:=1.20.2
+PKG_VERSION:=1.20.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/shadowsocks/shadowsocks-rust/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=555f0680621d6ebe19eb6b91356068ca7afabf5ef502bbe2a85d779af03e45b9
+PKG_HASH:=07d2301cb14d8e1ff653def167604e701ca9a05a140291875e0ec9e6334ad513
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
local: Ping Balancer scores replaced standard deviation with median absolute deviation, which should help focusing less on outlying observations in latency samples.
local-tun: Removes linking to SetInterfaceDnsSettings on Windows
chore(deps): bump blake3 from 1.5.2 to 1.5.3 by
chore(deps): bump thiserror from 1.0.62 to 1.0.63
chore(deps): bump openssl from 0.10.64 to 0.10.66

Full Changelog: https://github.com/shadowsocks/shadowsocks-rust/compare/v1.20.2...v1.20.3