### PR TITLE
shadowsocks-rust: update to 1.20.4

### DIFF
--- a/net/shadowsocks-rust/Makefile
+++ b/net/shadowsocks-rust/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=shadowsocks-rust
-PKG_VERSION:=1.20.3
+PKG_VERSION:=1.20.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/shadowsocks/shadowsocks-rust/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=07d2301cb14d8e1ff653def167604e701ca9a05a140291875e0ec9e6334ad513
+PKG_HASH:=cf064ad157974b3e396aab3bb60aab380dbc4e11b736603bfbc8e7a138f6bb26
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
For more information, visit https://github.com/shadowsocks/shadowsocks-rust/releases/tag/v1.20.4