### PR TITLE
[23.05]mosdns: Update to 5.3.3

### DIFF
--- a/net/mosdns/Makefile
+++ b/net/mosdns/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mosdns
-PKG_VERSION:=5.3.1
+PKG_VERSION:=5.3.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/IrineSistiana/mosdns/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=7c8c795de794df52fd2b51214826aea9ebde0dcd0da78d8dda9cc5e4ab98cd80
+PKG_HASH:=1d7eeaa735cb48ed2d436797d7f2a82541699f74647cd293ee411a72cdc65f5f
 
 PKG_LICENSE:=GPL-3.0
 PKG_LICENSE_FILES:=LICENSE

--- a/net/mosdns/Makefile
+++ b/net/mosdns/Makefile
@@ -36,8 +36,6 @@ define Package/mosdns
   PROVIDES:=mosdns-neo
 endef
 
-GO_PKG_TARGET_VARS:=$(filter-out CGO_ENABLED=%,$(GO_PKG_TARGET_VARS)) CGO_ENABLED=0
-
 define Package/mosdns/conffiles
 /etc/mosdns/
 endef

--- a/net/mosdns/patches/100-go-1.21.patch
+++ b/net/mosdns/patches/100-go-1.21.patch
@@ -1,0 +1,10 @@
+--- a/go.mod
++++ b/go.mod
+@@ -1,6 +1,6 @@
+ module github.com/IrineSistiana/mosdns/v5
+ 
+-go 1.22
++go 1.21
+ 
+ require (
+ 	github.com/IrineSistiana/go-bytes-pool v0.0.0-20230918115058-c72bd9761c57


### PR DESCRIPTION
mosdns: re-enable CGO(cherry picked from commit https://github.com/immortalwrt/packages/commit/b0761a2a40d4c1d0874c499bd3ccc6a46ce76919)
mosdns: Update to 5.3.3(cherry picked from commit https://github.com/immortalwrt/packages/commit/7a0177147419008e23c9641efbaf2f3d5bfcb4dd)
[added a patch to fix build with go 1.21]