### PR TITLE
nexttrace: Update to 1.3.3

### DIFF
--- a/net/nexttrace/Makefile
+++ b/net/nexttrace/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nexttrace
-PKG_VERSION:=1.3.2
+PKG_VERSION:=1.3.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/nxtrace/NTrace-core/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=30a22f9d94fafcb64a26bad490803a1434f5d695a4fc7d7dcbec73be7f0329f3
+PKG_HASH:=5823ade91cb2b26aa24583582b1d996170b2efdfd7038ade46c87419cab43b3b
 PKG_BUILD_DIR:=$(BUILD_DIR)/NTrace-core-$(PKG_VERSION)
 
 PKG_LICENSE:=GPL-3.0-only


### PR DESCRIPTION
https://github.com/nxtrace/NTrace-core/releases/tag/v1.3.3