### PR TITLE
n2n: Add missing header files

### DIFF
--- a/net/n2n/patches/101-Add-missing-header-zstd-build.patch
+++ b/net/n2n/patches/101-Add-missing-header-zstd-build.patch
@@ -1,0 +1,30 @@
+--- a/src/edge_utils.c
++++ b/src/edge_utils.c
+@@ -19,6 +19,7 @@
+ #include "n2n.h"
+ #include "network_traffic_filter.h"
+ #include "edge_utils_win32.h"
++#include <zstd.h>
+ 
+ /* heap allocation for compression as per lzo example doc */
+ #define HEAP_ALLOC(var,size) lzo_align_t __LZO_MMODEL var [ ((size) + (sizeof(lzo_align_t) - 1)) / sizeof(lzo_align_t) ]
+--- a/tools/n2n-benchmark.c
++++ b/tools/n2n-benchmark.c
+@@ -23,6 +23,7 @@
+ #endif
+ 
+ #include "n2n.h"
++#include <zstd.h>
+ 
+ #define DURATION                2.5   // test duration per algorithm
+ #define PACKETS_BEFORE_GETTIME  2047  // do not check time after every packet but after (2 ^ n - 1)
+--- a/tools/tests-compress.c
++++ b/tools/tests-compress.c
+@@ -22,6 +22,7 @@
+ 
+ #include "n2n.h"
+ #include "hexdump.h"
++#include <zstd.h>
+ 
+ /* heap allocation for compression as per lzo example doc */
+ #define HEAP_ALLOC(var,size) lzo_align_t __LZO_MMODEL var [ ((size) + (sizeof(lzo_align_t) - 1)) / sizeof(lzo_align_t) ]


### PR DESCRIPTION
target-aarch64_cortex-a53_musl/n2n-3.0/src/edge_utils.c:1685:36: warning: nested extern declaration of 'ZSTD_getErrorName' [-Wnested-externs]
/home/lin/ax6-6.x/build_dir/target-aarch64_cortex-a53_musl/n2n-3.0/src/edge_utils.c: In function 'edge_send_packet2net':
/home/lin/ax6-6.x/build_dir/target-aarch64_cortex-a53_musl/n2n-3.0/src/edge_utils.c:2245:44: error: implicit declaration of function 'ZSTD_compress' [-Wimplicit-function-declaration]