### PR TITLE
coremark: fix error when it was built in the second run

### DIFF
--- a/utils/coremark/Makefile
+++ b/utils/coremark/Makefile
@@ -69,8 +69,8 @@ endif
 
 define Build/Compile
 	$(SED) 's|EXE = .exe|EXE =|' $(PKG_BUILD_DIR)/posix/core_portme.mak
-	mkdir $(PKG_BUILD_DIR)/$(ARCH)
-	$(CP) -r $(PKG_BUILD_DIR)/linux/* $(PKG_BUILD_DIR)/$(ARCH)
+	[ -d "$(PKG_BUILD_DIR)/$(ARCH)" ] || mkdir $(PKG_BUILD_DIR)/$(ARCH)
+	$(CP) -r $(PKG_BUILD_DIR)/linux/* $(PKG_BUILD_DIR)/$(ARCH)/
 	$(MAKE) -C $(PKG_BUILD_DIR) PORT_DIR=$(ARCH) $(MAKE_FLAGS) \
 		PORT_CFLAGS="$(TARGET_CFLAGS)" XCFLAGS="$(EXTRA_CFLAGS)" compile
 endef


### PR DESCRIPTION
when there is an error building packages, and re-run with `make -j1 V=s`,  the coremark package will report error

`mkdir: cannot create directory '.../coremark-d5fad6bd094899101a4e5fd53af7298160ced6ab/XXX': File exists`

so, add a check to see if that dir is already there;

also add a '/' to the destination folder of the `cp` command

fixes #1380