### PR TITLE
geoview: update to 0.0.7

### DIFF
--- a/net/geoview/Makefile
+++ b/net/geoview/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=geoview
-PKG_VERSION:=0.0.6
+PKG_VERSION:=0.0.7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/snowie2000/geoview/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=f0da0db41a886d5a3ad34c0ad7d50eedc32b2e555ca42b65f7117d5cad60fc98
+PKG_HASH:=1099149d24b74ba6f4d4bca18aba4ffa0e29f8b3debb7f09b5972729ed11ca9c
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
- Compiled : x86-64 Debian 12
- Tested: x86-64 ImmortalWrt SNAPSHOT r32606-08e44a6900

- add a lookup feature for geoip.
- introduce low memory mode.