### PR TITLE
[24.10]nexttrace: Update to 1.3.7

### DIFF
--- a/net/nexttrace/Makefile
+++ b/net/nexttrace/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nexttrace
-PKG_VERSION:=1.3.6
+PKG_VERSION:=1.3.7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/nxtrace/NTrace-core/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=ddfae697445b0e86ddada4c0871f6cd7646f26bb2653b33b09e03becdebe7ced
+PKG_HASH:=94f8893f80b6b0a8d02b2fe709a62557034f3e32879a55807c38cb6ee2f8ab01
 PKG_BUILD_DIR:=$(BUILD_DIR)/NTrace-core-$(PKG_VERSION)
 
 PKG_LICENSE:=GPL-3.0-only
@@ -18,6 +18,7 @@ PKG_BUILD_PARALLEL:=1
 PKG_BUILD_FLAGS:=no-mips16
 
 GO_PKG:=github.com/nxtrace/NTrace-core
+GO_PKG_LDFLAGS:=-checklinkname=0
 GO_PKG_LDFLAGS_X:=$(GO_PKG)/config.Version=v$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Due to the update to Golang v1.23,
the "-ldflags=-checklinkname=0" flag is required during compilation.

(cherry picked from commit a02aa8624f047a493916d5c29781da76eda587c6)