### PR TITLE
rustdesk-server: add the init.d file for rustdesk-server

### DIFF
--- a/net/rustdesk-server/Makefile
+++ b/net/rustdesk-server/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rustdesk-server
 PKG_VERSION:=1.1.12
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/rustdesk/rustdesk-server/tar.gz/$(PKG_VERSION)?
@@ -32,6 +32,19 @@ endef
 
 define Package/rustdesk-server/description
   Self-host your own RustDesk server, it is free and open source.
+endef
+
+define Package/rustdesk-server/conffiles
+/etc/config/rustdesk
+/etc/rustdesk
+endef
+
+define Package/rustdesk-server/install
+	$(INSTALL_DIR) $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/bin/{hbbr,hbbs} $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/etc/config $(1)/etc/init.d/
+	$(INSTALL_BIN) ./files/rustdesk.conf $(1)/etc/config/rustdesk
+	$(INSTALL_BIN) ./files/rustdesk.init $(1)/etc/init.d/rustdesk
 endef
 
 $(eval $(call RustBinPackage,rustdesk-server))

--- a/net/rustdesk-server/files/rustdesk.conf
+++ b/net/rustdesk-server/files/rustdesk.conf
@@ -1,0 +1,11 @@
+config firewall 'firewall'
+	option auto_fw '0'
+	option web_client '0'
+
+config relay 'hbbr'
+	option enabled '0'
+	option port '21117'
+
+config server 'hbbs'
+	option enabled '0'
+	option port '21116'

--- a/net/rustdesk-server/files/rustdesk.init
+++ b/net/rustdesk-server/files/rustdesk.init
@@ -1,0 +1,104 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+START=99
+
+CONF="rustdesk"
+WORKDIR="/etc/rustdesk"
+
+start_service() {
+	local HBBS_TCP_PORTS=""
+	local HBBS_UDP_PORTS=""
+	local HBBR_TCP_PORTS=""
+
+	config_load "$CONF"
+	config_get_bool auto_fw "firewall" "auto_fw" "0"
+	config_get_bool web_client "firewall" "web_client" "0"
+	config_get_bool hbbr_enabled "hbbr" "enabled" "0"
+	config_get hbbr_port "hbbr" "port" "21117"
+	config_get_bool hbbs_enabled "hbbs" "enabled" "0"
+	config_get hbbs_port "hbbs" "port" "21116"
+
+	[ "$hbbr_enabled" -eq "1" ] || [ "$hbbs_enabled" -eq "1" ] || return 1
+
+	mkdir -p "$WORKDIR" || {
+		logger -p daemon.error -t "rustdesk" "Failed to create working directory: $WORKDIR"
+		return 1
+	}
+
+	if [ "$hbbr_enabled" -eq "1" ]; then
+		if [ "$web_client" -eq "0" ]; then
+			HBBR_TCP_PORTS="$hbbr_port"
+		else
+			HBBR_TCP_PORTS="$hbbr_port $(( hbbr_port + 2 ))"
+		fi
+
+		procd_open_instance "hbbr.relay"
+		procd_set_param command sh -c "cd $WORKDIR && /usr/bin/hbbr -p ${hbbr_port}"
+		procd_set_param respawn
+		if [ "$auto_fw" -eq "1" ]; then
+			procd_open_data
+			json_add_array firewall
+				json_add_object ""
+				json_add_string type rule
+				json_add_string name "Allow-rustdesk-relay-tcp"
+				json_add_string proto "tcp"
+				json_add_string src "wan"
+				json_add_string dest_port "$HBBR_TCP_PORTS"
+				json_add_string target "ACCEPT"
+				json_close_object
+			json_close_array
+			procd_close_data
+		fi
+		procd_close_instance
+	fi
+
+	if [ "$hbbs_enabled" -eq "1" ]; then
+		if [ "$web_client" -eq "0" ]; then
+			HBBS_TCP_PORTS="$(( hbbs_port - 1 )) $hbbs_port"
+		else
+			HBBS_TCP_PORTS="$(( hbbs_port - 1 )) $hbbs_port $(( hbbs_port + 2 ))"
+		fi
+		HBBS_UDP_PORTS="$hbbs_port"
+
+		procd_open_instance "hbbs.server"
+		procd_set_param command sh -c "cd $WORKDIR && /usr/bin/hbbs -p ${hbbs_port}"
+		procd_set_param respawn
+		if [ "$auto_fw" -eq "1" ]; then
+			procd_open_data
+			json_add_array firewall
+				json_add_object ""
+				json_add_string type rule
+				json_add_string name "Allow-rustdesk-server-tcp"
+				json_add_string proto "tcp"
+				json_add_string src "wan"
+				json_add_string dest_port "$HBBS_TCP_PORTS"
+				json_add_string target "ACCEPT"
+				json_close_object
+
+				json_add_object ""
+				json_add_string type rule
+				json_add_string name "Allow-rustdesk-server-udp"
+				json_add_string proto "udp"
+				json_add_string src "wan"
+				json_add_string dest_port "$HBBS_UDP_PORTS"
+				json_add_string target "ACCEPT"
+				json_close_object
+			json_close_array
+			procd_close_data
+		fi
+		procd_close_instance
+	fi
+}
+
+service_started() {
+	procd_set_config_changed firewall
+}
+
+service_stopped() {
+	procd_set_config_changed firewall
+}
+
+service_triggers() {
+	procd_add_reload_trigger "$CONF"
+}


### PR DESCRIPTION
- 添加了一个 init.d 文件，以实现在开机时自动启动 rustdesk-server。
- 由于程序本身不支持自定义工作目录，且 OpenWRT 的 init.d 不提供设置工作目录的参数，
  因此在 init 脚本中使用 cd 命令似乎是在不修改源代码前提下最佳的解决方案。
  在当前使用场景下，这种方法几乎不会影响性能。

已经部署到实际生产环境中运用，稳定运行无异常，于是重新提交pr