### PR TITLE
Update Rust to version 1.84.1

### DIFF
--- a/lang/rust/Makefile
+++ b/lang/rust/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rust
-PKG_VERSION:=1.84.0
+PKG_VERSION:=1.84.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=rustc-$(PKG_VERSION)-src.tar.gz
 PKG_SOURCE_URL:=https://static.rust-lang.org/dist/
-PKG_HASH:=15cee7395b07ffde022060455b3140366ec3a12cbbea8f1ef2ff371a9cca51bf
+PKG_HASH:=5e2fb5d49628a549f7671b2ccf9855ab379fd442831a7c2af16e0cdcc31bb375
 HOST_BUILD_DIR:=$(BUILD_DIR)/host/rustc-$(PKG_VERSION)-src
 
 PKG_MAINTAINER:=Luca Barbato <lu_zero@luminem.org>


### PR DESCRIPTION
```
PKG_NAME:=rust
PKG_VERSION:=1.84.1
PKG_RELEASE:=1

PKG_SOURCE:=rustc-$(PKG_VERSION)-src.tar.gz
PKG_SOURCE_URL:=https://static.rust-lang.org/dist/
PKG_HASH:=5e2fb5d49628a549f7671b2ccf9855ab379fd442831a7c2af16e0cdcc31bb375
HOST_BUILD_DIR:=$(BUILD_DIR)/host/rustc-$(PKG_VERSION)-src
```

[https://github.com/immortalwrt/packages/issues/1477](https://github.com/immortalwrt/packages/issues/1477)

因为1.84.0的下载地址为404，所以修改RUST的版本为1.84.1。

新地址拼接完为：`https://static.rust-lang.org/dist/rustc-1.84.1-src.tar.gz`
