### PR TITLE
rustdesk-server: revert "rustdesk-server: run as unprivileged user"

### DIFF
--- a/net/rustdesk-server/Makefile
+++ b/net/rustdesk-server/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rustdesk-server
 PKG_VERSION:=1.1.14
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/rustdesk/rustdesk-server.git
@@ -29,7 +29,6 @@ define Package/rustdesk-server
   TITLE:=RustDesk Server Program
   DEPENDS:=@(aarch64||arm||x86_64) @(!arm||TARGET_bcm53xx||HAS_FPU)
   URL:=https://rustdesk.com/server
-  USERID:=rustdesk-server:rustdesk-server
 endef
 
 define Package/rustdesk-server/description

--- a/net/rustdesk-server/files/rustdesk-server.init
+++ b/net/rustdesk-server/files/rustdesk-server.init
@@ -30,9 +30,9 @@ start_service() {
 	if [ "$hbbr_enabled" -eq "1" ]; then
 		procd_open_instance "hbbr"
 		procd_set_param command sh -c "cd $WORKDIR && /usr/bin/hbbr -p ${hbbr_port}"
+		procd_set_param stdout 1
+		procd_set_param stderr 1
 		procd_set_param respawn
-		procd_set_param user rustdesk-server
-		procd_set_param group rustdesk-server
 
 		if [ "$auto_fw" -eq "1" ]; then
 			if [ "$web_client" -eq "0" ]; then
@@ -60,9 +60,9 @@ start_service() {
 	if [ "$hbbs_enabled" -eq "1" ]; then
 		procd_open_instance "hbbs"
 		procd_set_param command sh -c "cd $WORKDIR && /usr/bin/hbbs -p ${hbbs_port}"
+		procd_set_param stdout 1
+		procd_set_param stderr 1
 		procd_set_param respawn
-		procd_set_param user rustdesk-server
-		procd_set_param group rustdesk-server
 
 		if [ "$auto_fw" -eq "1" ]; then
 			if [ "$web_client" -eq "0" ]; then


### PR DESCRIPTION
使用 `rustdesk-server` 用户会导致权限不足， 结果导致程序报错 `error [libs/hbb_common/src/config.rs:538] failed to store config: failed to create directory`。这似乎是因为目录的所有者权限设置为 `rustdesk-server`，但实际的所有者是 `rustdesk`（即使chown设置的是rustdesk-server:rustdesk-server）。使用默认的 `root` 用户运行时不会引起任何运行时问题。因此，权限被恢复为 root 用户相比来说更加合适。
此外建议openwrt用户这样设置或许更加合适，但是需要上游核心开发组进行协商讨论是否要引入这个特性以及具体实现标准和细节，所以给天灵老师提议：
![未命名绘图 drawio](https://github.com/user-attachments/assets/fe3f3e10-f92c-49a6-b236-9716a882a013)
