### PR TITLE
rustdesk-server: remove shell wrapper for init

### DIFF
--- a/net/rustdesk-server/Makefile
+++ b/net/rustdesk-server/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rustdesk-server
 PKG_VERSION:=1.1.14
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/rustdesk/rustdesk-server.git

--- a/net/rustdesk-server/files/rustdesk-server.init
+++ b/net/rustdesk-server/files/rustdesk-server.init
@@ -4,6 +4,7 @@ USE_PROCD=1
 START=99
 
 CONF="rustdesk-server"
+RUNDIR="/var/run/rustdesk-server"
 WORKDIR="/etc/rustdesk-server"
 
 start_service() {
@@ -21,17 +22,26 @@ start_service() {
 
 	[ "$hbbr_enabled" -eq "1" ] || [ "$hbbs_enabled" -eq "1" ] || return 1
 
-	if [ ! -d "$WORKDIR" ] && ! mkdir -p "$WORKDIR"; then
-		logger -p daemon.error -t "rustdesk-server" "Failed to create working directory: $WORKDIR"
-		return 1
-	fi
-	chown -R rustdesk-server:rustdesk-server "$WORKDIR"
+	for dir in "$RUNDIR" "$WORKDIR"; do
+		if [ ! -d "$dir" ] && ! mkdir -p "$dir"; then
+			logger -p daemon.error -t "rustdesk-server" "Failed to create working directory: $dir"
+			return 1
+		fi
+		chown -R rustdesk-server:rustdesk-server "$dir"
+	done
 
 	if [ "$hbbr_enabled" -eq "1" ]; then
 		procd_open_instance "hbbr"
-		procd_set_param command sh -c "cd $WORKDIR && /usr/bin/hbbr -p ${hbbr_port}"
+		procd_set_param command /usr/bin/hbbr
+
+		procd_set_param env PORT="${hbbr_port}"
+
+		procd_add_jail hbbr log procfs sysfs
+		procd_add_jail_mount "/etc/ssl/"
+		procd_add_jail_mount_rw "/etc/rustdesk-server/"
+		procd_add_jail_mount_rw "/var/run/rustdesk-server/"
+
 		procd_set_param respawn
-		procd_set_param env HOME="$WORKDIR"
 		procd_set_param user rustdesk-server
 		procd_set_param group rustdesk-server
 
@@ -60,9 +70,16 @@ start_service() {
 
 	if [ "$hbbs_enabled" -eq "1" ]; then
 		procd_open_instance "hbbs"
-		procd_set_param command sh -c "cd $WORKDIR && /usr/bin/hbbs -p ${hbbs_port}"
+		procd_set_param command /usr/bin/hbbs
+
+		procd_set_param env PORT="${hbbs_port}"
+
+		procd_add_jail hbbs log procfs sysfs
+		procd_add_jail_mount "/etc/ssl/"
+		procd_add_jail_mount_rw "/etc/rustdesk-server/"
+		procd_add_jail_mount_rw "/var/run/rustdesk-server/"
+
 		procd_set_param respawn
-		procd_set_param env HOME="$WORKDIR"
 		procd_set_param user rustdesk-server
 		procd_set_param group rustdesk-server
 
@@ -102,6 +119,10 @@ start_service() {
 
 service_started() {
 	procd_set_config_changed firewall
+}
+
+stop_service() {
+	rm -f "$RUNDIR"/hbbr*.log "$RUNDIR"/hbbs*.log
 }
 
 service_stopped() {

--- a/net/rustdesk-server/patches/001-hardcode-log-path.patch
+++ b/net/rustdesk-server/patches/001-hardcode-log-path.patch
@@ -1,0 +1,46 @@
+--- a/src/hbbr.rs
++++ b/src/hbbr.rs
+@@ -8,7 +8,19 @@ mod version;
+ 
+ fn main() -> ResultType<()> {
+     let _logger = Logger::try_with_env_or_str("info")?
+-        .log_to_stdout()
++        .log_to_file(
++            FileSpec::default()
++                .directory("/var/run/rustdesk-server")
++                .basename("hbbr")
++                .suffix("log")
++                .suppress_timestamp()
++        )
++        .rotate(
++            Criterion::Size(10_000_000),
++            Naming::Numbers,
++            Cleanup::KeepLogFiles(3),
++        )
++        .duplicate_to_stderr(Duplicate::Warn)
+         .format(opt_format)
+         .write_mode(WriteMode::Async)
+         .start()?;
+--- a/src/main.rs
++++ b/src/main.rs
+@@ -9,7 +9,19 @@ const RMEM: usize = 0;
+ 
+ fn main() -> ResultType<()> {
+     let _logger = Logger::try_with_env_or_str("info")?
+-        .log_to_stdout()
++        .log_to_file(
++            FileSpec::default()
++                .directory("/var/run/rustdesk-server")
++                .basename("hbbs")
++                .suffix("log")
++                .suppress_timestamp()
++        )
++        .rotate(
++            Criterion::Size(10_000_000),
++            Naming::Numbers,
++            Cleanup::KeepLogFiles(3),
++        )
++        .duplicate_to_stderr(Duplicate::Warn)
+         .format(opt_format)
+         .write_mode(WriteMode::Async)
+         .start()?;

--- a/net/rustdesk-server/patches/002-update-sk_file-path.patch
+++ b/net/rustdesk-server/patches/002-update-sk_file-path.patch
@@ -1,0 +1,11 @@
+--- a/src/common.rs
++++ b/src/common.rs
+@@ -105,7 +105,7 @@ pub fn now() -> u64 {
+ }
+ 
+ pub fn gen_sk(wait: u64) -> (String, Option<sign::SecretKey>) {
+-    let sk_file = "id_ed25519";
++    let sk_file = "/etc/rustdesk-server/id_ed25519";
+     if wait > 0 && !std::path::Path::new(sk_file).exists() {
+         std::thread::sleep(std::time::Duration::from_millis(wait));
+     }

--- a/net/rustdesk-server/patches/003-update-db-path.patch
+++ b/net/rustdesk-server/patches/003-update-db-path.patch
@@ -1,0 +1,21 @@
+--- a/src/peer.rs
++++ b/src/peer.rs
+@@ -68,17 +68,13 @@ pub(crate) struct PeerMap {
+ impl PeerMap {
+     pub(crate) async fn new() -> ResultType<Self> {
+         let db = std::env::var("DB_URL").unwrap_or({
+-            let mut db = "db_v2.sqlite3".to_owned();
++            let db = "/var/run/rustdesk-server/db_v2.sqlite3".to_owned();
+             #[cfg(all(windows, not(debug_assertions)))]
+             {
+                 if let Some(path) = hbb_common::config::Config::icon_path().parent() {
+                     db = format!("{}\\{}", path.to_str().unwrap_or("."), db);
+                 }
+             }
+-            #[cfg(not(windows))]
+-            {
+-                db = format!("./{db}");
+-            }
+             db
+         });
+         log::info!("DB_URL={}", db);

--- a/net/rustdesk-server/patches/004-update-config-path.patch
+++ b/net/rustdesk-server/patches/004-update-config-path.patch
@@ -1,0 +1,79 @@
+--- a/libs/hbb_common/src/config.rs
++++ b/libs/hbb_common/src/config.rs
+@@ -403,36 +403,6 @@ pub fn get_online_state() -> i64 {
+     *ONLINE.lock().unwrap().values().max().unwrap_or(&0)
+ }
+ 
+-#[cfg(not(any(target_os = "android", target_os = "ios")))]
+-fn patch(path: PathBuf) -> PathBuf {
+-    if let Some(_tmp) = path.to_str() {
+-        #[cfg(windows)]
+-        return _tmp
+-            .replace(
+-                "system32\\config\\systemprofile",
+-                "ServiceProfiles\\LocalService",
+-            )
+-            .into();
+-        #[cfg(target_os = "macos")]
+-        return _tmp.replace("Application Support", "Preferences").into();
+-        #[cfg(target_os = "linux")]
+-        {
+-            if _tmp == "/root" {
+-                if let Ok(user) = crate::platform::linux::run_cmds_trim_newline("whoami") {
+-                    if user != "root" {
+-                        let cmd = format!("getent passwd '{}' | awk -F':' '{{print $6}}'", user);
+-                        if let Ok(output) = crate::platform::linux::run_cmds_trim_newline(&cmd) {
+-                            return output.into();
+-                        }
+-                        return format!("/home/{user}").into();
+-                    }
+-                }
+-            }
+-        }
+-    }
+-    path
+-}
+-
+ impl Config2 {
+     fn load() -> Config2 {
+         let mut config = Config::load_::<Config2>("2");
+@@ -608,15 +578,7 @@ impl Config {
+         #[cfg(any(target_os = "android", target_os = "ios"))]
+         return PathBuf::from(APP_HOME_DIR.read().unwrap().as_str());
+         #[cfg(not(any(target_os = "android", target_os = "ios")))]
+-        {
+-            if let Some(path) = dirs_next::home_dir() {
+-                patch(path)
+-            } else if let Ok(path) = std::env::current_dir() {
+-                path
+-            } else {
+-                std::env::temp_dir()
+-            }
+-        }
++        PathBuf::from("/var/run/rustdesk-server")
+     }
+ 
+     pub fn path<P: AsRef<Path>>(p: P) -> PathBuf {
+@@ -628,19 +590,12 @@ impl Config {
+         }
+         #[cfg(not(any(target_os = "android", target_os = "ios")))]
+         {
+-            #[cfg(not(target_os = "macos"))]
+-            let org = "".to_owned();
+             #[cfg(target_os = "macos")]
+             let org = ORG.read().unwrap().clone();
+             // /var/root for root
+-            if let Some(project) =
+-                directories_next::ProjectDirs::from("", &org, &APP_NAME.read().unwrap())
+-            {
+-                let mut path = patch(project.config_dir().to_path_buf());
+-                path.push(p);
+-                return path;
+-            }
+-            "".into()
++            let mut path = PathBuf::from("/var/run/rustdesk-server");
++            path.push(p);
++            path
+         }
+     }
+ 

--- a/net/rustdesk-server/patches/005-fix-config-mac-fallback.patch
+++ b/net/rustdesk-server/patches/005-fix-config-mac-fallback.patch
@@ -1,0 +1,16 @@
+--- a/libs/hbb_common/src/config.rs
++++ b/libs/hbb_common/src/config.rs
+@@ -804,7 +804,12 @@ impl Config {
+                 id &= 0x1FFFFFFF;
+                 Some(id.to_string())
+             } else {
+-                None
++                log::warn!("Failed to get MAC address. Fallback to random ID");
++                Some(
++                    rand::thread_rng()
++                        .gen_range(1_000_000_000..2_000_000_000)
++                        .to_string(),
++                )
+             }
+         }
+     }


### PR DESCRIPTION
rustdesk-server: 去除init脚本中的hbbr和hbbs启动命令的shell包装
1.硬编码日志路径到/var/run/rustdesk-server
2.硬编码密钥生成路径到/etc/rustdesk-server
3.硬编码数据库文件到/var/run/rustdesk-server
4.硬编码配置文件到/var/run/rustdesk-server
5.增加无法获取mac地址的退回机制

其中：
1. 删除HOME环境变量，使用硬编码机制将配置文件生成到/var/run/rustdesk-server。源代码中所使用的库会首先获取环境变量的HOME目录，无法获取则退回到passwd中的用户路径，而openwrt中系统用户的路径一般为/var/run/系统用户名，则将运行路径硬编码为/var/run/rustdesk-server，相对符合习惯。
2. /var/run/rustdesk-server路径下的内容重启后会丢失，因其数据库文件、配置文件是运行中实时生成的，且会积累，需要定期清除，故硬编码到此路径可以减少对闪存的不必要的写入/擦除磨损。
3. 虽然源代码支持直接的日志输出，但是日志往往很多很杂，如果在init中启用stdout会使得系统日志可阅读性降低，故改为硬编码到本地的运行路径/var/run/rustdesk-server，这样即方便获取调试日志也不太影响系统日志的可阅读性。
4. 虽然几乎不会发生，但依然考虑到潜在的无法获取mac地址的情况，导致无法生成id，所以增加此情况下的随机id生成，增加程序运行的支持度。
5. 最佳解决方案依然是openwrt的procd服务支持设定工作路径的功能，本次提交patch只是在增加此功能前的兼容方案。

已经过约一周的测试，运行稳定。测试环境：r66s（rk3568 arm64）,openwrt 24.10(tag代码编译)