### PR TITLE
adguardhome: fix download error

### DIFF
--- a/net/adguardhome/Makefile
+++ b/net/adguardhome/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adguardhome
-PKG_VERSION:=0.107.57
+PKG_VERSION:=0.107.59
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz


### PR DESCRIPTION
Fix adguardhome pkg download error: hash mismatch due to the version's  mistake.

```
+ curl -f --connect-timeout 20 --retry 5 --location https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.57/AdGuardHome_frontend.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 2403k  100 2403k    0     0   680k      0  0:00:03  0:00:03 --:--:-- 1203k
Hash of the downloaded file does not match (file: fc0b57d80dece4219bfba833b48122ffe7a140ee2026cd3cf4c7181ccdcf8c9e, requested: 955051153aafdc924a7a4b05307628bd91b3b22c68c8f3e3c49a8b44e052c285) - deleting download.
```