### PR TITLE
zerotier: fw4: Use exit-code to determine whether to use delay

### DIFF
--- a/net/zerotier/Makefile
+++ b/net/zerotier/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zerotier
 PKG_VERSION:=1.14.1
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/zerotier/ZeroTierOne/tar.gz/$(PKG_VERSION)?

--- a/net/zerotier/files/usr/bin/zerotier-fw4
+++ b/net/zerotier/files/usr/bin/zerotier-fw4
@@ -41,7 +41,7 @@ while getopts "i:s" arg; do
 		wait=0
 		until [ "$wait" -ge "10" ]; do
 			zerotier_info="$(zerotier-cli -j info)"
-			[ -n "$zerotier_info" ] && break
+			[ "$?" -eq "0" ] && break
 			sleep 2s
 			let wait+=2
 		done


### PR DESCRIPTION
`zerotier_info="$(zerotier-cli -j info)"`在zerotier启动过程中，返回的状态码为1，zerotier_info的值为错误信息。
在脚本中插入`zerotier-cli -j info|tee /tmp/zt.log`进行调试发现其在状态码为1时，zt.log中也存在错误信息。
所以改用`$?`判断是否成功获取信息。