### PR TITLE
Fix Unable to find folder during compilation

### DIFF
--- a/libs/libffi/Makefile
+++ b/libs/libffi/Makefile
@@ -77,7 +77,7 @@ define Build/InstallDev
 		$(PKG_INSTALL_DIR)/usr/include/*.h \
 		$(1)/usr/include/
 	$(CP) \
-		$(PKG_BUILD_DIR)/$(GNU_TARGET_NAME)-gnu/fficonfig.h \
+		$(PKG_BUILD_DIR)/$(GNU_TARGET_NAME)/fficonfig.h \
 		$(1)/usr/include/
 endef
 


### PR DESCRIPTION
编译`libffi`时报错找不到`aarch64-openwrt-linux-gnu`文件夹，经查看生成的是`aarch64-openwrt-linux`文件夹，删除`libffi`的`Makefile`文件中的`-gnu`字段即可编译成功
````
make[3]: Entering directory '/mnt/openwrt/feeds/packages/libs/libffi'
rm -rf /mnt/openwrt/tmp/stage-libffi
mkdir -p /mnt/openwrt/tmp/stage-libffi/host /mnt/openwrt/staging_dir/target-aarch64_cortex-a53_musl/packages
install -d -m0755 /mnt/openwrt/tmp/stage-libffi/usr/lib/pkgconfig
cp -fpR /mnt/openwrt/build_dir/target-aarch64_cortex-a53_musl/libffi-3.4.6/ipkg-install/usr/lib/libffi.{so*,a,la} /mnt/openwrt/tmp/stage-libffi/usr/lib/
cp -fpR /mnt/openwrt/build_dir/target-aarch64_cortex-a53_musl/libffi-3.4.6/ipkg-install/usr/lib/pkgconfig/* /mnt/openwrt/tmp/stage-libffi/usr/lib/pkgconfig/
/mnt/openwrt/staging_dir/host/bin/sed -i -e 's,includedir=.*,includedir=${prefix}/include,' /mnt/openwrt/tmp/stage-libffi/usr/lib/pkgconfig/libffi.pc
install -d -m0755 /mnt/openwrt/tmp/stage-libffi/usr/include
cp -fpR /mnt/openwrt/build_dir/target-aarch64_cortex-a53_musl/libffi-3.4.6/ipkg-install/usr/include/*.h /mnt/openwrt/tmp/stage-libffi/usr/include/
cp -fpR /mnt/openwrt/build_dir/target-aarch64_cortex-a53_musl/libffi-3.4.6/aarch64-openwrt-linux-gnu/fficonfig.h /mnt/openwrt/tmp/stage-libffi/usr/include/
cp: cannot stat '/mnt/openwrt/build_dir/target-aarch64_cortex-a53_musl/libffi-3.4.6/aarch64-openwrt-linux-gnu/fficonfig.h': No such file or directory
make[3]: *** [Makefile:101: /mnt/openwrt/staging_dir/target-aarch64_cortex-a53_musl/stamp/.libffi_installed] Error 1
make[3]: Leaving directory '/mnt/openwrt/feeds/packages/libs/libffi'
time: package/feeds/packages/libffi/compile#0.12#0.16#0.25
    ERROR: package/feeds/packages/libffi failed to build.
make[2]: *** [package/Makefile:179: package/feeds/packages/libffi/compile] Error 1
make[2]: Leaving directory '/mnt/openwrt'
make[1]: *** [package/Makefile:173: /mnt/openwrt/staging_dir/target-aarch64_cortex-a53_musl/stamp/.package_compile] Error 2
make[1]: Leaving directory '/mnt/openwrt'
make: *** [/mnt/openwrt/include/toplevel.mk:233: world] Error 2