### PR TITLE
fibocom-qmi-wwan: fix build error "missing-prototypes"

### DIFF
--- a/kernel/fibocom-qmi-wwan/Makefile
+++ b/kernel/fibocom-qmi-wwan/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fibocom-qmi-wwan
 PKG_VERSION:=1.0.5
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@IMMORTALWRT

--- a/kernel/fibocom-qmi-wwan/patches/010-fix-build-for-kernel-6.6.patch
+++ b/kernel/fibocom-qmi-wwan/patches/010-fix-build-for-kernel-6.6.patch
@@ -36,6 +36,15 @@
  
  #ifdef FIBOCOM_BRIDGE_MODE
      priv->bridge_mode = !!(pDev->bridge_mode & BIT(offset_id));
+@@ -1319,7 +1331,7 @@ typedef struct {
+     unsigned int dl_minimum_padding; //0x1A
+ } QMAP_SETTING;
+
+-int qma_setting_store(struct device *dev, QMAP_SETTING *qmap_settings, size_t size) {
++static int qma_setting_store(struct device *dev, QMAP_SETTING *qmap_settings, size_t size) {
+     struct net_device *netdev = to_net_dev(dev);
+     struct usbnet * usbnetdev = netdev_priv( netdev );
+     struct qmi_wwan_state *info = (void *)&usbnetdev->data;
 @@ -1760,8 +1772,14 @@ static void ql_net_get_drvinfo(struct ne
  {
      /* Inherit standard device info */

--- a/kernel/fibocom-qmi-wwan/patches/010-fix-build-for-kernel-6.6.patch
+++ b/kernel/fibocom-qmi-wwan/patches/010-fix-build-for-kernel-6.6.patch
@@ -39,7 +39,7 @@
 @@ -1319,7 +1331,7 @@ typedef struct {
      unsigned int dl_minimum_padding; //0x1A
  } QMAP_SETTING;
-
+ 
 -int qma_setting_store(struct device *dev, QMAP_SETTING *qmap_settings, size_t size) {
 +static int qma_setting_store(struct device *dev, QMAP_SETTING *qmap_settings, size_t size) {
      struct net_device *netdev = to_net_dev(dev);


### PR DESCRIPTION
to fix the following error:
```
make[4]: Entering directory '/mnt/workdir/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/linux-6.12.31'
  CC [M]  /mnt/workdir/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/fibocom-qmi-wwan-1.0.5/qmi_wwan_f.o
/mnt/workdir/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/fibocom-qmi-wwan-1.0.5/qmi_wwan_f.c:1334:5: error: no previous prototype for 'qma_setting_store' [-Werror=missing-prototypes]
 1334 | int qma_setting_store(struct device *dev, QMAP_SETTING *qmap_settings, size_t size) {
      |     ^~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[6]: *** [scripts/Makefile.build:229: /mnt/workdir/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/fibocom-qmi-wwan-1.0.5/qmi_wwan_f.o] Error 1
make[5]: *** [/mnt/workdir/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/linux-6.12.31/Makefile:1945: /mnt/workdir/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/fibocom-qmi-wwan-1.0.5] Error 2
```
build tested on BPi-R3 mini with FM150-AE

Signed-off-by: Rye Sears <xlighting@gmail.com>