### PR TITLE
quectel-qmi-wwan: fix build error "missing-prototypes"

### DIFF
--- a/kernel/quectel-qmi-wwan/Makefile
+++ b/kernel/quectel-qmi-wwan/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=quectel-qmi-wwan
 PKG_VERSION:=1.2.9
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@IMMORTALWRT

--- a/kernel/quectel-qmi-wwan/patches/011-fix-build-for-kernel-6.12.patch
+++ b/kernel/quectel-qmi-wwan/patches/011-fix-build-for-kernel-6.12.patch
@@ -1,8 +1,8 @@
 --- a/qmi_wwan_q.c
 +++ b/qmi_wwan_q.c
 @@ -1472,7 +1472,7 @@ typedef struct {
- } BRMAC_SETTING;
- #endif
+} BRMAC_SETTING;
+#endif
 
 -int qma_setting_store(struct device *dev, QMAP_SETTING *qmap_settings, size_t size) {
 +static int qma_setting_store(struct device *dev, QMAP_SETTING *qmap_settings, size_t size) {

--- a/kernel/quectel-qmi-wwan/patches/011-fix-build-for-kernel-6.12.patch
+++ b/kernel/quectel-qmi-wwan/patches/011-fix-build-for-kernel-6.12.patch
@@ -1,11 +1,11 @@
 --- a/qmi_wwan_q.c
 +++ b/qmi_wwan_q.c
-@@ -1473,7 +1473,7 @@ typedef struct {
+@@ -1472,7 +1472,7 @@ typedef struct {
  } BRMAC_SETTING;
  #endif
 
 -int qma_setting_store(struct device *dev, QMAP_SETTING *qmap_settings, size_t size) {
 +static int qma_setting_store(struct device *dev, QMAP_SETTING *qmap_settings, size_t size) {
-        struct net_device *netdev = to_net_dev(dev);
-        struct usbnet * usbnetdev = netdev_priv( netdev );
-        struct qmi_wwan_state *info = (void *)&usbnetdev->data;
+ 	struct net_device *netdev = to_net_dev(dev);
+ 	struct usbnet * usbnetdev = netdev_priv( netdev );
+ 	struct qmi_wwan_state *info = (void *)&usbnetdev->data;

--- a/kernel/quectel-qmi-wwan/patches/011-fix-build-for-kernel-6.12.patch
+++ b/kernel/quectel-qmi-wwan/patches/011-fix-build-for-kernel-6.12.patch
@@ -1,0 +1,11 @@
+--- a/qmi_wwan_q.c
++++ b/qmi_wwan_q.c
+@@ -1473,7 +1473,7 @@ typedef struct {
+ } BRMAC_SETTING;
+ #endif
+
+-int qma_setting_store(struct device *dev, QMAP_SETTING *qmap_settings, size_t size) {
++static int qma_setting_store(struct device *dev, QMAP_SETTING *qmap_settings, size_t size) {
+        struct net_device *netdev = to_net_dev(dev);
+        struct usbnet * usbnetdev = netdev_priv( netdev );
+        struct qmi_wwan_state *info = (void *)&usbnetdev->data;

--- a/kernel/quectel-qmi-wwan/patches/011-fix-build-for-kernel-6.12.patch
+++ b/kernel/quectel-qmi-wwan/patches/011-fix-build-for-kernel-6.12.patch
@@ -1,9 +1,9 @@
 --- a/qmi_wwan_q.c
 +++ b/qmi_wwan_q.c
 @@ -1472,7 +1472,7 @@ typedef struct {
-} BRMAC_SETTING;
-#endif
-
+ } BRMAC_SETTING;
+ #endif
+ 
 -int qma_setting_store(struct device *dev, QMAP_SETTING *qmap_settings, size_t size) {
 +static int qma_setting_store(struct device *dev, QMAP_SETTING *qmap_settings, size_t size) {
  	struct net_device *netdev = to_net_dev(dev);


### PR DESCRIPTION
the quectel-qmi-wwan also show build error: missing-prototypes with kernel 6.12;
therefore, add a new patch to fix it

Signed-off-by: Rye Sears <xlighting@gmail.com>