### PR TITLE
shadow-tls: add package

### DIFF
--- a/net/shadow-tls/Makefile
+++ b/net/shadow-tls/Makefile
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: GPL-3.0-only
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=shadow-tls
+PKG_VERSION:=0.2.25
+PKG_RELEASE:=1
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/ihciah/shadow-tls.git
+PKG_SOURCE_VERSION:=dee3a5a819d6f56cfdd56c44a0d42be186c44238
+PKG_MIRROR_HASH:=skip
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:= SakuraFallingMad
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/shadow-tls-$(PKG_VERSION)
+
+PKG_BUILD_DEPENDS:=rust/host
+PKG_USE_MIPS16:=0
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/rust/rust-package.mk
+
+define Package/shadow-tls
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Web Servers/Proxies
+  TITLE:=Shadow-TLS: A proxy to evade censorship
+  URL:=https://github.com/ihciah/shadow-tls
+  DEPENDS:=+libopenssl
+endef
+
+define Package/shadow-tls/description
+  Shadow-TLS is a proxy to evade DPI and censorship, designed to mimic TLS traffic.
+endef
+
+define Build/Compile
+	CARGO_TARGET_$(call UPPERCASE,$(RUSTC_TARGET_NAME))_LINKER="$(TARGET_CC)" \
+		cargo build --release --target $(RUSTC_TARGET_NAME) --features tokio-runtime
+endef
+
+define Package/shadow-tls/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$$(INSTALL_BIN) $$(PKG_INSTALL_DIR)/bin/$(1) $$(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,shadow-tls))

--- a/net/shadow-tls/Makefile
+++ b/net/shadow-tls/Makefile
@@ -1,48 +1,60 @@
-# SPDX-License-Identifier: GPL-3.0-only
+# SPDX-License-Identifier: GPL-2.0-only
+
 include $(TOPDIR)/rules.mk
+include $(INCLUDE_DIR)/package.mk
 
 PKG_NAME:=shadow-tls
 PKG_VERSION:=0.2.25
 PKG_RELEASE:=1
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/ihciah/shadow-tls.git
-PKG_SOURCE_VERSION:=dee3a5a819d6f56cfdd56c44a0d42be186c44238
-PKG_MIRROR_HASH:=skip
 
-PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
-PKG_MAINTAINER:= SakuraFallingMad
+PKG_MAINTAINER:=FluffyTigerFear
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/shadow-tls-$(PKG_VERSION)
+RELEASE_HEAD:=$(PKG_NAME)
+RELEASE_FOOT:=unknown-linux-musl
 
-PKG_BUILD_DEPENDS:=rust/host
-PKG_USE_MIPS16:=0
-PKG_BUILD_PARALLEL:=1
+ifeq ($(ARCH),aarch64)
+	RELEASE_ARCH:=$(RELEASE_HEAD)-aarch64-$(RELEASE_FOOT)
+	PKG_HASH:=3295476b37f549a68906519d3eaecb74bf3b6eaf9094cebb16ee84f0151373c6
+else ifeq ($(ARCH),arm)
+    ifeq ($(CONFIG_CPU_TYPE),cortex-a7)
+        RELEASE_ARCH:=$(RELEASE_HEAD)-armv7-$(RELEASE_FOOT)eabihf
+        PKG_HASH:=e6f918a072557c50fd0ea950af9a156a9b102af72c1d010ff85d08d13006c54f
+    else ifeq ($(CONFIG_CPU_TYPE),cortex-a9)
+        RELEASE_ARCH:=$(RELEASE_HEAD)-armv7-$(RELEASE_FOOT)eabihf
+        PKG_HASH:=e6f918a072557c50fd0ea950af9a156a9b102af72c1d010ff85d08d13006c54f
+    else
+        RELEASE_ARCH:=$(RELEASE_HEAD)-arm-$(RELEASE_FOOT)eabi
+        PKG_HASH:=b6743bc60e1727972ece0fd5acf3a931e5be05cedee6f637e7e3d8c5b8d58f16
+    endif
+else ifeq ($(ARCH),x86_64)
+	RELEASE_ARCH:=$(RELEASE_HEAD)-x86_64-$(RELEASE_FOOT)
+	PKG_HASH:=a173f5f2d57f45211b68e10ceeddc15b1791077b914fa89747bc705fddc71532
+else
+	PKG_SOURCE:=dummy
+	PKG_HASH:=dummy
+endif
 
-include $(INCLUDE_DIR)/package.mk
-include ../../lang/rust/rust-package.mk
+define Download/shadow-tls
+  FILE:=$(PKG_SOURCE)
+  URL:=$(PKG_SOURCE_URL)
+  URL_FILE:=$(PKG_SOURCE)
+  HASH:=$(PKG_HASH)
+endef
+$(eval $(call Download,shadow-tls))
 
 define Package/shadow-tls
-  SECTION:=net
-  CATEGORY:=Network
-  SUBMENU:=Web Servers/Proxies
-  TITLE:=Shadow-TLS: A proxy to evade censorship
-  URL:=https://github.com/ihciah/shadow-tls
-  DEPENDS:=+libopenssl
-endef
-
-define Package/shadow-tls/description
-  Shadow-TLS is a proxy to evade DPI and censorship, designed to mimic TLS traffic.
-endef
-
-define Build/Compile
-	CARGO_TARGET_$(call UPPERCASE,$(RUSTC_TARGET_NAME))_LINKER="$(TARGET_CC)" \
-		cargo build --release --target $(RUSTC_TARGET_NAME) --features tokio-runtime
+	SECTION:=net
+	CATEGORY:=Network
+	SUBMENU:=Web Servers/Proxies
+	TITLE:=A proxy to expose real tls handshake to the firewall.
+	URL:=https://github.com/ihciah/shadow-tls
+	DEPENDS:=@USE_MUSL @(aarch64||arm||x86_64) @!(TARGET_x86_geode||TARGET_x86_legacy)
 endef
 
 define Package/shadow-tls/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$$(INSTALL_BIN) $$(PKG_INSTALL_DIR)/bin/$(1) $$(1)/usr/bin/
+	$(INSTALL_BIN) $(DL_DIR)/$(RELEASE_ARCH) $(1)/usr/bin/shadow-tls
 endef
 
 $(eval $(call BuildPackage,shadow-tls))

--- a/net/shadow-tls/Makefile
+++ b/net/shadow-tls/Makefile
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: GPL-3.0-only
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=shadow-tls
+PKG_VERSION:=0.2.25
+PKG_RELEASE:=1
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/ihciah/shadow-tls.git
+PKG_SOURCE_VERSION:=dee3a5a819d6f56cfdd56c44a0d42be186c44238
+PKG_MIRROR_HASH:=skip
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:= SakuraFallingMad
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/shadow-tls-$(PKG_VERSION)
+
+PKG_BUILD_DEPENDS:=rust/host
+PKG_USE_MIPS16:=0
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/rust/rust-package.mk
+
+define Package/shadow-tls
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Web Servers/Proxies
+  TITLE:=Shadow-TLS: A proxy to evade censorship
+  URL:=https://github.com/ihciah/shadow-tls
+  DEPENDS:=+libopenssl
+endef
+
+define Package/shadow-tls/description
+  Shadow-TLS is a proxy to evade DPI and censorship, designed to mimic TLS traffic.
+endef
+
+define Build/Compile
+	CARGO_TARGET_$(call UPPERCASE,$(RUSTC_TARGET_NAME))_LINKER="$(TARGET_CC)" \
+		SHADOW_TLS_RUNTIME=tokio \
+		cargo build --release --target $(RUSTC_TARGET_NAME)
+endef
+
+define Package/shadow-tls/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$$(INSTALL_BIN) $$(PKG_INSTALL_DIR)/bin/$(1) $$(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,shadow-tls))


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @FluffyTigerFear
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
A proxy to expose real tls handshake to the firewall.

---

## 🧪 Run Testing Details

- **ImmortalWrt Version:ImmortalWrt SNAPSHOT r34816-228840f6cd
- **ImmortalWrt Target/Subtarget:x86-64
