### PR TITLE
fan2go: add new package

### DIFF
--- a/utils/fan2go/Makefile
+++ b/utils/fan2go/Makefile
@@ -1,0 +1,70 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=fan2go
+PKG_VERSION:=0.11.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/markusressel/fan2go/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=02baca96ed1be6824e9bf6ca33198f94cc9319af44e04677a7f9c55c60abb319
+
+PKG_LICENSE:=AGPL-3.0
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Dee.H.Y <dongfengweixiao@hotmail.com>
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_BUILD_FLAGS:=no-mips16
+
+GO_PKG:=github.com/markusressel/fan2go
+GO_PKG_LDFLAGS_X:=$(GO_PKG)/cmd/global.Version=$(PKG_VERSION)
+GO_PKG_TAGS:=netgo,disable_nvml
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/fan2go
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=dynamic fan speed control
+  URL:=https://github.com/markusressel/fan2go
+  DEPENDS:=$(GO_ARCH_DEPENDS) +libsensors
+endef
+
+define Package/fan2go/description
+  A simple daemon providing dynamic fan speed control based on
+  temperature sensors.
+endef
+
+define Package/fan2go/conffiles
+/etc/fan2go/fan2go.db
+/etc/fan2go/fan2go.yaml
+endef
+
+define Package/fan2go/install
+	$(call GoPackage/Package/Install/Bin,$(1))
+
+	$(INSTALL_DIR) $(1)/etc/fan2go
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/fan2go.yaml $(1)/etc/fan2go/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/fan2go.init $(1)/etc/init.d/fan2go
+endef
+
+define Package/fan2go/postinst
+#!/bin/sh
+if [ -z "$${IPKG_INSTROOT}" ]; then
+	touch "/etc/sensors3.conf"
+fi
+exit 0
+endef
+
+define Package/fan2go/prerm
+#!/bin/sh
+if [ -z "$${IPKG_INSTROOT}" ]; then
+	[ -s "/etc/sensors3.conf" ] || rm -f "/etc/sensors3.conf"
+fi
+exit 0
+endef
+
+$(eval $(call GoBinPackage,fan2go))
+$(eval $(call BuildPackage,fan2go))

--- a/utils/fan2go/files/fan2go.init
+++ b/utils/fan2go/files/fan2go.init
@@ -1,0 +1,15 @@
+#!/bin/sh /etc/rc.common
+
+START=60
+USE_PROCD=1
+
+PROG=/usr/bin/fan2go
+CONFIG=/etc/fan2go/fan2go.yaml
+
+start_service() {
+	[ -f "$CONFIG" ] || { echo "fan2go: $CONFIG is missing"; return 1; }
+	procd_open_instance
+	procd_set_param command $PROG -c "${CONFIG}" --no-style
+	procd_set_param respawn
+	procd_close_instance
+}


### PR DESCRIPTION
## 📦 Package Details

A simple daemon providing dynamic fan speed
control based on temperature sensors.

**Description:**
该二进制文件用于在linux平台上通过 sensors 读取传感器数据后控制风扇转速。
该二进制文件运行时需要在/etc/目录下手动创建一个空的sensors3.conf
(标准linux在lm-sensors中包含有该文件，但是op精简掉了，fan2go编译时依赖的一个库中
存在对该文件的判断，如果找不到该文件程序无法运行，那个库7年没更新了)。

PS：[not following template](https://github.com/immortalwrt/packages/labels/not%20following%20template) 在该仓库中代表什么？
