### PR TITLE
tcping: Replace with the version supporting IPv6

### DIFF
--- a/net/tcping/Makefile
+++ b/net/tcping/Makefile
@@ -6,24 +6,32 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tcping
 PKG_VERSION:=0.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/Mattraks/tcping/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=c703481d1751adf051dd3391c4dccdadc6dfca7484e636222b392e1213312e02
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/Lienol/tcping
+PKG_MIRROR_HASH:=79414cd8e1d124422a36b8fe36a1f296b7d9bde99807b2c90ad81bbd65e200e0
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_VERSION:=db9101834732dac9aaa59dbb7fb9c74612dbf723
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)/$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_LICENSE:=GPL-2.0-only
 PKG_LICENSE_FILES:=license.txt
 
-PKG_BUILD_PARALLEL:=1
-
 include $(INCLUDE_DIR)/package.mk
 
 define Package/tcping
-  SECTION:=net
-  CATEGORY:=Network
-  TITLE:=tcping measures the latency of a tcp-connection
-  URL:=https://github.com/jlyo/tcping
+	SECTION:=net
+	CATEGORY:=Network
+	TITLE:=tcping measures the latency of a tcp-connection
+	URL:=https://github.com/jlyo/tcping
+endef
+
+define Package/tcping/description
+endef
+
+define Package/tcping/conffiles
 endef
 
 define Package/tcping/install


### PR DESCRIPTION
经过实测，目前 Mattraks 的版本不支持IPv6的地址或域名，而 Lienol 的版本支持。
两个版本的命令行参数以及输出格式均一致，对于用户来说可以无损替换。