### PR TITLE
softethervpn5: Update to 5.2.5188

### DIFF
--- a/net/softethervpn5/Makefile
+++ b/net/softethervpn5/Makefile
@@ -3,7 +3,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=softethervpn5
-PKG_VERSION:=5.02.5184
+PKG_VERSION:=5.2.5188
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0
@@ -11,7 +11,7 @@ PKG_LICENSE_FILES:=COPYING
 
 PKG_SOURCE_URL:=https://github.com/SoftEtherVPN/SoftEtherVPN/releases/download/$(PKG_VERSION)/
 PKG_SOURCE:=SoftEtherVPN-$(PKG_VERSION).tar.xz
-PKG_HASH:=7459f321ec957d160f95ccf5fccc46be6f2c26bd78f0bcdf03d53ae131d051f5
+PKG_HASH:=e89278e7edd7e137bd521851b42c2bf9ce4e5cae2489db406588d3388646b147
 
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/SoftEtherVPN-$(PKG_VERSION)
 PKG_BUILD_DIR:=$(BUILD_DIR)/SoftEtherVPN-$(PKG_VERSION)
@@ -83,7 +83,9 @@ export USE_MUSL=YES
 # BUG: outdated host/include/elf.h
 HOST_CFLAGS += $(FPIC) -DAT_HWCAP2=26
 TARGET_CFLAGS += $(FPIC)
-CMAKE_OPTIONS += -DICONV_LIB_PATH="$(ICONV_PREFIX)/lib"
+CMAKE_OPTIONS += \
+	-DICONV_LIB_PATH="$(ICONV_PREFIX)/lib" \
+	-DOQS_PERMIT_UNSUPPORTED_ARCHITECTURE=ON
 
 # static build for host (hamcorebuilder), avoid -fpic on ncurses/host and shared libs can't be found on host
 define Host/Prepare

--- a/net/softethervpn5/patches/001-iconv-cmake-fix.patch
+++ b/net/softethervpn5/patches/001-iconv-cmake-fix.patch
@@ -1,6 +1,6 @@
 --- a/src/Mayaqua/CMakeLists.txt
 +++ b/src/Mayaqua/CMakeLists.txt
-@@ -80,7 +80,7 @@ if(UNIX)
+@@ -96,7 +96,7 @@ if(UNIX)
    find_package(Threads REQUIRED)
  
    # In some cases libiconv is not included in libc

--- a/net/softethervpn5/patches/102-remove-region-restriction.patch
+++ b/net/softethervpn5/patches/102-remove-region-restriction.patch
@@ -1,0 +1,10 @@
+--- a/src/Cedar/Server.c
++++ b/src/Cedar/Server.c
+@@ -10754,6 +10754,7 @@ void SiGetCurrentRegion(CEDAR *c, char *
+ // 
+ bool SiIsEnterpriseFunctionsRestrictedOnOpenSource(CEDAR *c)
+ {
++	return false;
+ 	char region[128];
+ 	bool ret = false;
+ 	// Validate arguments


### PR DESCRIPTION
## 📦 Package Details

**Description:**
Update softethervpn5 to 5.2.5188
also removed region restriction.

Enabled "Enterprise Functions":

RADIUS / NT Domain user authentication
RSA certificate authentication
Deep-inspect packet logging
Source IP address control list
syslog transfer
Classless Static Route support (DHCP option 121)

---

## 🧪 Run Testing Details

- **ImmortalWrt Version:** 24.10
- **ImmortalWrt Target/Subtarget:** x86_64
- **ImmortalWrt Device:** Esxi 7

---

## ✅ Formalities

- [ √] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [× ] It can be applied using `git am`
- [√ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [√] It is structured in a way that it is potentially upstreamable
<sub>softethervpn5: Update to 5.2.5188</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
