### PR TITLE
修复libffi中makefile导致的编译失败

### DIFF
--- a/libs/libffi/Makefile
+++ b/libs/libffi/Makefile
@@ -76,7 +76,7 @@ define Build/InstallDev
 		$(PKG_INSTALL_DIR)/usr/include/*.h \
 		$(1)/usr/include/
 	$(CP) \
-		$(PKG_BUILD_DIR)/$(GNU_TARGET_NAME)-gnu/fficonfig.h \
+		$(PKG_BUILD_DIR)/$(GNU_TARGET_NAME)/fficonfig.h \
 		$(1)/usr/include/
 endef
 


### PR DESCRIPTION
fix err

## 📦 Package Details

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
$(CP) \
		$(PKG_BUILD_DIR)/$(GNU_TARGET_NAME)**-gnu**/fficonfig.h \
		$(1)/usr/include/
这里多加了-gnu，会导致找不到fficonfig.h。

---

## 🧪 Run Testing Details

- **ImmortalWrt Version:**
- **ImmortalWrt Target/Subtarget:**
- **ImmortalWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
