### PR TITLE
[ADGuardHome] Fix init script

### DIFF
--- a/net/adguardhome/files/adguardhome.init
+++ b/net/adguardhome/files/adguardhome.init
@@ -21,7 +21,6 @@ start_service() {
 		return 0
 	fi
 
-	local enabled
 	local config_file
 	local group
 	local pid_file
@@ -30,10 +29,6 @@ start_service() {
 	local work_dir
 
 	config_load adguardhome
-
-	config_get_bool enabled config enabled 0
-	[ "$enabled" -eq "1" ] || return 1
-
 	config_get config_file config config "/etc/adguardhome/adguardhome.yaml"
 	config_get work_dir config workdir "/var/lib/adguardhome"
 	config_get pid_file config pidfile "/run/adguardhome.pid"


### PR DESCRIPTION
## 📦 Package Details

Fix #1685 

## 🧪 Run Testing Details

- **ImmortalWrt Version: SNAPSHOT** 
- **ImmortalWrt Target/Subtarget: x86/64**
- **ImmortalWrt Device: x86/64**

---

## ✅ Formalities

- [√] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
