### PR TITLE
trojan: Fix `boost 1.89 versions` build.

### DIFF
--- a/net/trojan/Makefile
+++ b/net/trojan/Makefile
@@ -52,7 +52,17 @@ define Package/trojan
   URL:=https://github.com/trojan-gfw/trojan
   DEPENDS:= \
     +libpthread +libstdcpp +libopenssl \
-    +boost +boost-system +boost-program_options +boost-date_time
+    +boost +boost-program_options +boost-date_time \
+    +@TROJAN_BOOST_SYSTEM:boost-system
+endef
+
+define Package/trojan/config
+	config TROJAN_BOOST_SYSTEM
+		bool "Include boost-system depends (required for Boost < 1.89.0)"
+		default y if PACKAGE_boost-system
+		help
+			Select this option if your Boost version is lower than 1.89.0.
+			For Boost versions 1.89.0 and above, the system library is integrated into the main boost library.
 endef
 
 define Package/trojan/install

--- a/net/trojan/patches/002-Fix-boost1.89-build.patch
+++ b/net/trojan/patches/002-Fix-boost1.89-build.patch
@@ -1,0 +1,101 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -21,7 +21,13 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
+ find_package(Threads REQUIRED)
+ target_link_libraries(trojan ${CMAKE_THREAD_LIBS_INIT})
+ 
+-find_package(Boost 1.66.0 REQUIRED COMPONENTS system program_options)
++find_package(Boost 1.66.0 REQUIRED)
++if(Boost_VERSION LESS 108900)
++    find_package(Boost 1.66.0 REQUIRED COMPONENTS system program_options)
++else()
++    find_package(Boost 1.66.0 REQUIRED COMPONENTS program_options)
++endif()
++
+ target_include_directories(trojan PRIVATE ${Boost_INCLUDE_DIR})
+ target_link_libraries(trojan ${Boost_LIBRARIES})
+ if(MSVC)
+--- a/src/core/service.cpp
++++ b/src/core/service.cpp
+@@ -36,6 +36,9 @@
+ #include "session/natsession.h"
+ #include "ssl/ssldefaults.h"
+ #include "ssl/sslsession.h"
++#if BOOST_VERSION >= 108900
++#include <boost/system.hpp>
++#endif
+ using namespace std;
+ using namespace boost::asio::ip;
+ using namespace boost::asio::ssl;
+--- a/src/main.cpp
++++ b/src/main.cpp
+@@ -28,6 +28,9 @@
+ #endif // ENABLE_MYSQL
+ #include "core/service.h"
+ #include "core/version.h"
++#if BOOST_VERSION >= 108900
++#include <boost/system.hpp>
++#endif
+ using namespace std;
+ using namespace boost::asio;
+ namespace po = boost::program_options;
+--- a/src/session/clientsession.cpp
++++ b/src/session/clientsession.cpp
+@@ -21,6 +21,9 @@
+ #include "proto/trojanrequest.h"
+ #include "proto/udppacket.h"
+ #include "ssl/sslsession.h"
++#if BOOST_VERSION >= 108900
++#include <boost/system.hpp>
++#endif
+ using namespace std;
+ using namespace boost::asio::ip;
+ using namespace boost::asio::ssl;
+--- a/src/session/forwardsession.cpp
++++ b/src/session/forwardsession.cpp
+@@ -20,6 +20,9 @@
+ #include "forwardsession.h"
+ #include "proto/trojanrequest.h"
+ #include "ssl/sslsession.h"
++#if BOOST_VERSION >= 108900
++#include <boost/system.hpp>
++#endif
+ using namespace std;
+ using namespace boost::asio::ip;
+ using namespace boost::asio::ssl;
+--- a/src/session/natsession.cpp
++++ b/src/session/natsession.cpp
+@@ -20,6 +20,9 @@
+ #include "natsession.h"
+ #include "proto/trojanrequest.h"
+ #include "ssl/sslsession.h"
++#if BOOST_VERSION >= 108900
++#include <boost/system.hpp>
++#endif
+ using namespace std;
+ using namespace boost::asio::ip;
+ using namespace boost::asio::ssl;
+--- a/src/session/serversession.cpp
++++ b/src/session/serversession.cpp
+@@ -20,6 +20,9 @@
+ #include "serversession.h"
+ #include "proto/trojanrequest.h"
+ #include "proto/udppacket.h"
++#if BOOST_VERSION >= 108900
++#include <boost/system.hpp>
++#endif
+ using namespace std;
+ using namespace boost::asio::ip;
+ using namespace boost::asio::ssl;
+--- a/src/session/udpforwardsession.cpp
++++ b/src/session/udpforwardsession.cpp
+@@ -23,6 +23,9 @@
+ #include "ssl/sslsession.h"
+ #include "proto/trojanrequest.h"
+ #include "proto/udppacket.h"
++#if BOOST_VERSION >= 108900
++#include <boost/system.hpp>
++#endif
+ using namespace std;
+ using namespace boost::asio::ip;
+ using namespace boost::asio::ssl;


### PR DESCRIPTION
boost 1.89 versions: Boost.System is now a header-only library.
