### PR TITLE
trojan: Fix `boost 1.89 ver` build.

### DIFF
--- a/net/trojan/Makefile
+++ b/net/trojan/Makefile
@@ -52,7 +52,7 @@ define Package/trojan
   URL:=https://github.com/trojan-gfw/trojan
   DEPENDS:= \
     +libpthread +libstdcpp +libopenssl \
-    +boost +boost-system +boost-program_options +boost-date_time
+    +boost +boost-program_options +boost-date_time
 endef
 
 define Package/trojan/install

--- a/net/trojan/patches/002-Fix-boost1.89-build.patch
+++ b/net/trojan/patches/002-Fix-boost1.89-build.patch
@@ -1,6 +1,6 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -36,7 +36,13 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
+@@ -36,7 +36,12 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
  find_package(Threads REQUIRED)
  target_link_libraries(trojan ${CMAKE_THREAD_LIBS_INIT})
  
@@ -11,7 +11,6 @@
 +else()
 +    find_package(Boost 1.66.0 REQUIRED COMPONENTS program_options)
 +endif()
-+
  include_directories(${Boost_INCLUDE_DIR})
  target_link_libraries(trojan ${Boost_LIBRARIES})
  if(MSVC)

--- a/net/trojan/patches/002-Fix-boost1.89-build.patch
+++ b/net/trojan/patches/002-Fix-boost1.89-build.patch
@@ -1,0 +1,17 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -36,7 +36,13 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
+ find_package(Threads REQUIRED)
+ target_link_libraries(trojan ${CMAKE_THREAD_LIBS_INIT})
+ 
+-find_package(Boost 1.66.0 REQUIRED COMPONENTS system program_options)
++find_package(Boost 1.66.0 REQUIRED)
++if (Boost_MAJOR_VERSION LESS_EQUAL 1 AND Boost_MINOR_VERSION LESS 89)
++    find_package(Boost 1.66.0 REQUIRED COMPONENTS system program_options)
++else()
++    find_package(Boost 1.66.0 REQUIRED COMPONENTS program_options)
++endif()
++
+ include_directories(${Boost_INCLUDE_DIR})
+ target_link_libraries(trojan ${Boost_LIBRARIES})
+ if(MSVC)


### PR DESCRIPTION
**boost 1.89 versions: Boost.System is now a header-only library.**
