### PR TITLE
cups: disable internal stripping of cupsd executables

### DIFF
--- a/utils/cups/Makefile
+++ b/utils/cups/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cups
 PKG_VERSION:=2.3.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-source.tar.gz
 PKG_SOURCE_URL:=https://github.com/apple/cups/releases/download/v$(PKG_VERSION)/
@@ -104,6 +104,7 @@ CONFIGURE_ARGS+= \
 	--enable-default-shared \
 	--enable-shared \
 	--enable-libusb \
+	--enable-debug \
 	--disable-acl \
 	--disable-dnssd \
 	--disable-dbus \


### PR DESCRIPTION
The cupsd build system's internal stripping process (not the OpenWrt stripping which is already disabled) corrupts the ELF header with the current toolchain, removing the AArch64 machine architecture identification.

Before stripping: cupsd: ELF 64-bit LSB pie executable, ARM aarch64, ...
After stripping: cupsd.stripped: ELF 64-bit LSB pie executable, no machine, ...

This causes the kernel to fail to recognize the stripped binary as a valid aarch64 executable.