### PR TITLE
boost: fixed ` boost-system ` missing

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -72,6 +72,7 @@ This package provides the following run-time libraries:
  - regex
  - serialization and wserialization
  - stackstrace
+ - system
  - thread
  - timer
  - type_erasure
@@ -362,6 +363,7 @@ $(eval $(call DefineBoostLibrary,regex,,,,icu))
 $(eval $(call DefineBoostLibrary,serialization))
 $(eval $(call DefineBoostLibrary,wserialization,serialization))
 $(eval $(call DefineBoostLibrary,stacktrace))
+$(eval $(call DefineBoostLibrary,system))
 $(eval $(call DefineBoostLibrary,thread,chrono atomic container date_time))
 $(eval $(call DefineBoostLibrary,timer,chrono))
 $(eval $(call DefineBoostLibrary,type_erasure,chrono thread))


### PR DESCRIPTION
## 📦 Package Details

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
fixed `boost-system` missing
```
WARNING: Makefile 'package/feeds/packages/domoticz/Makefile' has a dependency on 'boost-system', which does not exist
WARNING: Makefile 'package/feeds/packages/i2pd/Makefile' has a dependency on 'boost-system', which does not exist
WARNING: Makefile 'package/feeds/packages/kea/Makefile' has a dependency on 'boost-system', which does not exist
WARNING: Makefile 'package/luci-app-qbittorrent/rblibtorrent/Makefile' has a dependency on 'boost-system', which does not exist
```
---

## 🧪 Run Testing Details

- **ImmortalWrt Version: ImmortalWrt SNAPSHOT r0-dd350bc
- **ImmortalWrt Target/Subtarget: qualcommax/ipq807x
- **ImmortalWrt Device: Aliyun AP8220

---

## ✅ Formalities

- [*] I have reviewed the [CONTRIBUTING.md](https://github.com/immortalwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [*] It can be applied using `git am`
- [*] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [*] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
