### PR TITLE
adguardhome: remove enable flag to align with mainline OpenWRT

### DIFF
--- a/net/adguardhome/files/adguardhome.config
+++ b/net/adguardhome/files/adguardhome.config
@@ -1,5 +1,4 @@
 config adguardhome 'config'
-	option enabled '0'
 	# All paths except for PID must be readable by the configured user
 	option config '/etc/adguardhome/adguardhome.yaml'
 	# Where to store persistent data by AdGuard Home

--- a/net/adguardhome/files/adguardhome.init
+++ b/net/adguardhome/files/adguardhome.init
@@ -21,7 +21,6 @@ start_service() {
 		return 0
 	fi
 
-	local enabled
 	local config_file
 	local group
 	local pid_file
@@ -30,10 +29,6 @@ start_service() {
 	local work_dir
 
 	config_load adguardhome
-
-	config_get_bool enabled config enabled 0
-	[ "$enabled" -eq "1" ] || return 1
-
 	config_get config_file config config "/etc/adguardhome/adguardhome.yaml"
 	config_get work_dir config workdir "/var/lib/adguardhome"
 	config_get pid_file config pidfile "/run/adguardhome.pid"


### PR DESCRIPTION
## 📦 Package Details

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

In ImmortalWRT, you'll need to explicitly edit the /etc/config/adguardhome file, and modify enable to "1" in order to use AdguardHome, which is not the case in mainline OpenWRT

I've compared the difference and submit this PR to remove the extra flag 

---

## 🧪 Run Testing Details

- **ImmortalWrt Version:**
- **ImmortalWrt Target/Subtarget:**
- **ImmortalWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/immortalwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
