### PR TITLE
nexttrace: bump to v1.5.0

### DIFF
--- a/net/nexttrace/Makefile
+++ b/net/nexttrace/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nexttrace
-PKG_VERSION:=1.4.2
+PKG_VERSION:=1.5.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/nxtrace/NTrace-core/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=ab9f91320f16673dbf450ed3c1790eb4e4786934a1f5a0817eb82a582f09d1eb
+PKG_HASH:=6def8e05d0311aa864e6faf99884ae408fa4c2705232671c334224fa0e34cd3b
 PKG_BUILD_DIR:=$(BUILD_DIR)/NTrace-core-$(PKG_VERSION)
 
 PKG_LICENSE:=GPL-3.0-only


### PR DESCRIPTION
## 📦 Package Details

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
bump nexttrace to v1.5.0
---

## 🧪 Run Testing Details

- **ImmortalWrt Version:**
- **ImmortalWrt Target/Subtarget:**
- **ImmortalWrt Device:**

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/immortalwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
