### PR TITLE
Enhance DNS record selection logic in update_aliyun_com.sh

### DIFF
--- a/net/ddns-scripts/files/usr/lib/ddns/update_aliyun_com.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_aliyun_com.sh
@@ -131,7 +131,7 @@ fi
 if [ -n "$specRecordId" ]; then
     write_log 7 "specRecordId: ${specRecordId}"
     idx=1
-    while json_is_a $idx object && [ "$found_match" = false ]
+    while json_is_a $idx object
     do
         json_select $idx
         json_get_var tmp RecordId
@@ -141,6 +141,7 @@ if [ -n "$specRecordId" ]; then
             json_get_var __RECORD_VALUE Value
             write_log 7 "The $idx Domain Record Value: ${__RECORD_VALUE}"
             found_match=true
+			break
         fi
         idx=$((idx+1))
         json_select ..

--- a/net/ddns-scripts/files/usr/lib/ddns/update_aliyun_com.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_aliyun_com.sh
@@ -113,10 +113,52 @@ json_get_var __RECORD_COUNT TotalCount
 # select the first DNS record
 json_select DomainRecords
 json_select Record
-json_select 1
-# get the record id of the first DNS record
-json_get_var __RECORD_ID RecordId
-json_get_var __RECORD_VALUE Value
+
+# Log the original parameter
+write_log 7 "param_enc: `echo ${param_enc}`"
+paramEnc=${param_enc}
+
+# Initialize variables
+specRecordId=""
+found_match=false
+
+# Extract RecordId from parameters
+if [ -n "$(echo "${paramEnc}" | grep RecordId)" ]; then
+    specRecordId=$(echo "$paramEnc" | grep -o 'RecordId=[^&]*' | cut -d'=' -f2)
+fi
+
+# If RecordId is successfully extracted, try to match it
+if [ -n "$specRecordId" ]; then
+    write_log 7 "specRecordId: ${specRecordId}"
+    idx=1
+    while json_is_a $idx object && [ "$found_match" = false ]
+    do
+        json_select $idx
+        json_get_var tmp RecordId
+        write_log 7 "The $idx Domain RecordId: ${tmp}"
+        if [ "$tmp" = "$specRecordId" ]; then
+            __RECORD_ID=$specRecordId
+            json_get_var __RECORD_VALUE Value
+            write_log 7 "The $idx Domain Record Value: ${__RECORD_VALUE}"
+            found_match=true
+        fi
+        idx=$((idx+1))
+        json_select ..
+    done
+fi
+
+# Fallback to default logic if no match found
+if [ "$found_match" = false ]; then
+    write_log 7 "Using default logic to select record"
+    # If multiple records are found, only use the first one
+    if [ "$__RECORD_COUNT" -gt 1 ]; then
+        write_log 4 "WARNING: found multiple records of $__HOST, only use the first one"
+    fi
+    json_select 1
+    # Get the record id of the first DNS record
+    json_get_var __RECORD_ID RecordId
+    json_get_var __RECORD_VALUE Value
+fi
 
 # dont update if the ip has not changed
 [ "$__RECORD_VALUE" = "$__IP" ] && {


### PR DESCRIPTION
Added logic to extract and match specific DNS record ID from parameters, with fallback to default selection if no match is found.

## 📦 Package Details

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **ImmortalWrt Version:**
- **ImmortalWrt Target/Subtarget:**
- **ImmortalWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/immortalwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
