### PR TITLE
修复rust失效资源

### DIFF
--- a/lang/rust/Makefile
+++ b/lang/rust/Makefile
@@ -75,7 +75,7 @@ HOST_CONFIGURE_ARGS = \
 	--release-channel=stable \
 	--enable-cargo-native-static \
 	--bootstrap-cache-path=$(DL_DIR)/rustc \
-	--set=llvm.download-ci-llvm=true \
+	--set=llvm.download-ci-llvm=false \
 	$(TARGET_CONFIGURE_ARGS)
 
 define Host/Uninstall


### PR DESCRIPTION
ci-artifacts.rust-lang.org  的资源已经失效，直接从源下载