### PR TITLE
podman: Update to 5.8.1

### DIFF
--- a/utils/podman/Makefile
+++ b/utils/podman/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=podman
-PKG_VERSION:=5.2.2
+PKG_VERSION:=5.8.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/containers/podman/archive/v$(PKG_VERSION)
-PKG_HASH:=571658f175d61724269c1a20626c1e39424af59b7bcf7ff94135d03b790bbecb
+PKG_HASH:=b9540ecb19cfcbcfc40e1b81d39930f688c537d8fd6f11ae56be41f2bf9e97a4
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -99,12 +99,12 @@ define Package/podman/install
 	$(INSTALL_DIR) $(1)/etc/containers
 	$(INSTALL_DATA) $(DL_DIR)/default-policy.json-362f70b056 $(1)/etc/containers/policy.json
 	$(INSTALL_DATA) $(DL_DIR)/registries.fedora-da9a9c8778 $(1)/etc/containers/registries.conf
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/vendor/github.com/containers/storage/storage.conf $(1)/etc/containers/storage.conf
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/vendor/go.podman.io/storage/storage.conf $(1)/etc/containers/storage.conf
 	$(INSTALL_DATA) ./files/containers.conf $(1)/etc/containers/containers.conf
 	$(INSTALL_DIR) $(1)/etc/containers/networks
 	$(INSTALL_CONF) ./files/podman.json $(1)/etc/containers/networks
 	$(INSTALL_DIR) $(1)/usr/share/containers
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/vendor/github.com/containers/common/pkg/seccomp/seccomp.json $(1)/usr/share/containers/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/vendor/go.podman.io/common/pkg/seccomp/seccomp.json $(1)/usr/share/containers/
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/podman.init $(1)/etc/init.d/podman
 	$(SED) 's/driver = \"\"/driver = \"overlay\"/g' $(1)/etc/containers/storage.conf

--- a/utils/podman/patches/010-do-not-build-docs.patch
+++ b/utils/podman/patches/010-do-not-build-docs.patch
@@ -1,6 +1,6 @@
 --- a/Makefile
 +++ b/Makefile
-@@ -230,7 +230,7 @@ GV_VERSION=v0.7.4
+@@ -234,7 +234,7 @@ GVPROXY_VERSION=$(shell $(GO) list -m -f
  default: all
  
  .PHONY: all
@@ -8,13 +8,13 @@
 +all: binaries
  
  .PHONY: binaries
- ifeq ($(shell uname -s),FreeBSD)
-@@ -853,7 +853,7 @@ rpm-install: package  ## Install rpm pac
+ ifeq ($(GOOS),freebsd)
+@@ -868,7 +868,7 @@ rpm-install: package  ## Install rpm pac
  	/usr/bin/podman info  # will catch a broken conmon
  
  .PHONY: install
 -install: install.bin install.remote install.man install.systemd  ## Install binaries to system locations
 +install: install.bin install.remote install.systemd  ## Install binaries to system locations
  
- .PHONY: install.catatonit
- install.catatonit:
+ .PHONY: install.remote
+ install.remote:


### PR DESCRIPTION
## 📦 Package Details

**Description:**
Update Podman to the latest v5.8.1 and refresh the origin patch file. 
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **ImmortalWrt Version:  ImmortalWrt 25.12-SNAPSHOT r0-abc9103**
- **ImmortalWrt Target/Subtarget:  X86-64**
- **ImmortalWrt Device:  CncTion Tiger Lake-6L**

---

## ✅ Formalities

- [√] I have reviewed the [CONTRIBUTING.md](https://github.com/immortalwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
