### PR TITLE
daed: update to 1.26.0

### DIFF
--- a/net/daed/Makefile
+++ b/net/daed/Makefile
@@ -5,13 +5,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=daed
-PKG_VERSION:=1.24.0
+PKG_VERSION:=1.26.0
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/daeuniverse/daed.git
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
-PKG_MIRROR_HASH:=7ad5835df49e64338a66349fdba69c90b6eddcdbf4b5b93623cc9e7cbe0920e0
+PKG_MIRROR_HASH:=f8499e3682b28250f2267fbb31dfc6ae89b129c0b83906ec206a301898e3dd2d
 
 PKG_LICENSE:=AGPL-3.0-only MIT
 PKG_LICENSE_FILES:=LICENSE wing/LICENSE
@@ -81,7 +81,7 @@ define Download/daed-web
 	URL:=https://github.com/daeuniverse/daed/releases/download/v$(PKG_VERSION)
 	URL_FILE:=web.zip
 	FILE:=$(WEB_FILE)
-	HASH:=30378e7a988b842b5d174af5cb6475ff2074ad948d7d99dbcf2213e1d6e1f277
+	HASH:=b46874ddabc246af2e14c9230c7b15227d3c3cee5e56a1271d1932d25acd5f88
 endef
 
 define Build/Prepare


### PR DESCRIPTION
## 📦 Package Details

**Description:** it's a regular update form 1.24.0(now) to 1.26.0(latest)
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **ImmortalWrt Version:** ImmortalWrt 25.12-SNAPSHOT r0-62bd6b3
- **ImmortalWrt Target/Subtarget:** x86/64
- **ImmortalWrt Device:** CncTion Tiger Lake-6L

---

## ✅ Formalities

- [√] I have reviewed the [CONTRIBUTING.md](https://github.com/immortalwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
