### PR TITLE
daed: update to 1.27.0

### DIFF
--- a/net/daed/Makefile
+++ b/net/daed/Makefile
@@ -5,13 +5,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=daed
-PKG_VERSION:=1.26.0
+PKG_VERSION:=1.27.0
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/daeuniverse/daed.git
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
-PKG_MIRROR_HASH:=f8499e3682b28250f2267fbb31dfc6ae89b129c0b83906ec206a301898e3dd2d
+PKG_MIRROR_HASH:=f848f70c6f1fb4fb43d6bfe14de81a5653ff6fa5e65ba0fd1f5970af97ed8739
 
 PKG_LICENSE:=AGPL-3.0-only MIT
 PKG_LICENSE_FILES:=LICENSE wing/LICENSE
@@ -81,7 +81,7 @@ define Download/daed-web
 	URL:=https://github.com/daeuniverse/daed/releases/download/v$(PKG_VERSION)
 	URL_FILE:=web.zip
 	FILE:=$(WEB_FILE)
-	HASH:=b46874ddabc246af2e14c9230c7b15227d3c3cee5e56a1271d1932d25acd5f88
+	HASH:=da8755fb2cabfab392854e807e385b12d9e9842d6c8b5e347284d1ae0e582bfc
 endef
 
 define Build/Prepare


### PR DESCRIPTION
## 📦 Package Details

**Description:** it's a regular update form 1.26.0(now) to 1.27.0(latest)
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **ImmortalWrt Version:** ImmortalWrt 25.12-SNAPSHOT r0-0b15286
- **ImmortalWrt Target/Subtarget:** x86/64
- **ImmortalWrt Device:** CncTion Tiger Lake-6L

---

## ✅ Formalities

- [ √ ] I have reviewed the [CONTRIBUTING.md](https://github.com/immortalwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
