### PR TITLE
[codex] qbittorrent: disable MIPS16

### DIFF
--- a/net/qbittorrent/Makefile
+++ b/net/qbittorrent/Makefile
@@ -15,6 +15,7 @@ PKG_CPE_ID:=cpe:/a:qbittorrent:qbittorrent
 
 PKG_BUILD_DEPENDS:=qt6tools/host
 PKG_BUILD_PARALLEL:=1
+PKG_BUILD_FLAGS:=no-mips16
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk


### PR DESCRIPTION
### What changed\nAdd PKG_BUILD_FLAGS:=no-mips16 to the qBittorrent package.\n\n### Why\nThe MT7621 mipsel_24kc package currently emits Qt QObject::connect signal-not-found warnings and never brings up the WebUI. Qt6 itself already disables MIPS16 in its package; qBittorrent was missing the same restriction. MIPS16 can break Qt/C++ ABI and meta-object signal dispatch.\n\n### Validation\nThe official packages CI should build the changed package for mipsel_24kc/mt7621. Router deployment is intentionally deferred until CI and package-level WebUI/RSS checks pass.