### PR TITLE
dae: update to 2.0.0

### DIFF
--- a/net/dae/Makefile
+++ b/net/dae/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dae
-PKG_VERSION:=1.0.0
+PKG_VERSION:=2.0.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).zip
 PKG_SOURCE_URL:=https://github.com/daeuniverse/dae/releases/download/v$(PKG_VERSION)/dae-full-src.zip?
-PKG_HASH:=d933b93fc30cb4e9941cbb1be23557bd6caa2a33af212883505fec435d06fc13
+PKG_HASH:=89853731fbc6ca60e4a68644e774fa45927fc53e7c05b19b9308fc938b1b98c2
 
 PKG_LICENSE:=AGPL-3.0-only
 PKG_LICENSE_FILE:=LICENSE


### PR DESCRIPTION
Update dae to 2.0.0

# 📦 Package Details

**Description:** it's a regular update form 1.0.0 to 2.0.0
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **ImmortalWrt Version:** 25.12.0, master
- **ImmortalWrt Target/Subtarget:** x86/64, aarch64
- **ImmortalWrt Device:** tested on BPI-R4

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/immortalwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/dae/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
