### PR TITLE
dae: update to 2.0.0

### DIFF
--- a/net/dae/Makefile
+++ b/net/dae/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dae
-PKG_VERSION:=1.0.0
+PKG_VERSION:=2.0.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).zip
 PKG_SOURCE_URL:=https://github.com/daeuniverse/dae/releases/download/v$(PKG_VERSION)/dae-full-src.zip?
-PKG_HASH:=d933b93fc30cb4e9941cbb1be23557bd6caa2a33af212883505fec435d06fc13
+PKG_HASH:=89853731fbc6ca60e4a68644e774fa45927fc53e7c05b19b9308fc938b1b98c2
 
 PKG_LICENSE:=AGPL-3.0-only
 PKG_LICENSE_FILE:=LICENSE


### PR DESCRIPTION
## Package Details

Updates dae from 1.0.0 to 2.0.0 on the openwrt-25.12 branch.

This backports the version and source hash change already merged into master as immortalwrt/packages@502338a0. The source archive requires Go 1.26, which is already the default Go version on openwrt-25.12.

## Testing

- ImmortalWrt version: openwrt-25.12 (25.12.1)
- Target/subtarget: package metadata change; CI will cover supported architectures
- Device: not runtime-tested locally
- Independently downloaded the official v2.0.0 full-source archive and verified SHA-256: `89853731fbc6ca60e4a68644e774fa45927fc53e7c05b19b9308fc938b1b98c2`
- Verified the diff matches the version/hash change already merged in master
- `git diff --check` passes

## Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/immortalwrt/packages/blob/master/CONTRIBUTING.md) file.
- [x] Commit includes a matching Signed-off-by line.

This PR does not add or modify downstream patches.