### PR TITLE
nexttrace: bump to v1.7.2

### DIFF
--- a/net/nexttrace/Makefile
+++ b/net/nexttrace/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nexttrace
-PKG_VERSION:=1.6.2
+PKG_VERSION:=1.7.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/nxtrace/NTrace-core/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=1d65e38e7d555bc165dd2b2235fa076418f2adb5c4766a91f1f44ec083298f85
+PKG_HASH:=e57b1884cede897cafbb2294c133193dc3db51e16771b6b2affab58c24e03507
 PKG_BUILD_DIR:=$(BUILD_DIR)/NTrace-core-$(PKG_VERSION)
 
 PKG_LICENSE:=GPL-3.0-only


### PR DESCRIPTION
## 📦 Package Details

**Description:** nexttrace: bump to v1.7.2
<!-- Briefly describe what this package does or what changes are introduced -->
Release notes:
https://github.com/nxtrace/NTrace-core/releases/tag/v1.7.2
---

## 🧪 Run Testing Details

- **ImmortalWrt Version:** 
- **ImmortalWrt Target/Subtarget:** x86/64
- **ImmortalWrt Device:** VirtualBox

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/immortalwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
